### PR TITLE
Recycle authenticated user uid header...

### DIFF
--- a/lib/govuk_sidekiq/api_headers.rb
+++ b/lib/govuk_sidekiq/api_headers.rb
@@ -8,8 +8,15 @@ module GovukSidekiq
     # https://github.com/mperham/sidekiq/wiki/Middleware#client-side-middleware
     class ClientMiddleware
       def call(worker_class, job, queue, redis_pool)
-        job["args"] << { request_id: GdsApi::GovukHeaders.headers[:govuk_request_id] }
+        job["args"] << header_arguments
         yield
+      end
+
+      def header_arguments
+        {
+          authenticated_user: GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user],
+          request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
+        }
       end
     end
 
@@ -20,10 +27,12 @@ module GovukSidekiq
       def call(worker, message, queue)
         last_arg = message["args"].last
 
-        if last_arg.is_a?(Hash) && last_arg.keys == ["request_id"]
+        if last_arg.is_a?(Hash) && last_arg.keys.include?("request_id")
           message["args"].pop
           request_id = last_arg["request_id"]
+          authenticated_user = last_arg["authenticated_user"]
           GdsApi::GovukHeaders.set_header(:govuk_request_id, request_id)
+          GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, authenticated_user)
         end
 
         yield

--- a/spec/api_headers_spec.rb
+++ b/spec/api_headers_spec.rb
@@ -3,9 +3,11 @@ require "govuk_sidekiq/api_headers"
 
 RSpec.describe GovukSidekiq::APIHeaders::ClientMiddleware do
   let(:govuk_request_id) { "some-unique-request-id" }
+  let(:govuk_authenticated_user) { "some-unique-user-id" }
 
-  it "adds the govuk_request_id to the job arguments" do
+  it "adds the govuk_request_id and govuk_authenticated_user to the job arguments" do
     GdsApi::GovukHeaders.set_header(:govuk_request_id, govuk_request_id)
+    GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, govuk_authenticated_user)
 
     job = {
       "args" => []
@@ -13,24 +15,27 @@ RSpec.describe GovukSidekiq::APIHeaders::ClientMiddleware do
 
     described_class.new.call("worker_class", job, "queue", "redis_pool") do
       expect(job["args"].last[:request_id]).to eq(govuk_request_id)
+      expect(job["args"].last[:authenticated_user]).to eq(govuk_authenticated_user)
     end
   end
 end
 
 RSpec.describe GovukSidekiq::APIHeaders::ServerMiddleware do
   let(:govuk_request_id) { "some-unique-request-id" }
+  let(:govuk_authenticated_user) { "some-unique-user-id" }
 
   it "removes the govuk_request_id from the job arguments ands adds it to the API headers" do
     message = {
       "args" => [
         "some arg",
-        { "request_id" => govuk_request_id },
+        { "authenticated_user" => govuk_authenticated_user, "request_id" => govuk_request_id },
       ]
     }
 
     described_class.new.call("worker", message, "queue") do
       expect(message["args"]).to eq(["some arg"])
       expect(GdsApi::GovukHeaders.headers[:govuk_request_id]).to eq(govuk_request_id)
+      expect(GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user]).to eq(govuk_authenticated_user)
     end
   end
 
@@ -43,6 +48,8 @@ RSpec.describe GovukSidekiq::APIHeaders::ServerMiddleware do
     }
 
     original_message = message.dup
+
+    expect(GdsApi::GovukHeaders).not_to receive(:set_header)
 
     described_class.new.call("worker", message, "queue") do
       expect(message).to eq(original_message)
@@ -58,22 +65,7 @@ RSpec.describe GovukSidekiq::APIHeaders::ServerMiddleware do
 
     original_message = message.dup
 
-    described_class.new.call("worker", message, "queue") do
-      expect(message).to eq(original_message)
-    end
-  end
-
-  it "does nothing if the last argument is a hash with extra keys" do
-    message = {
-      "args" => [
-        {
-          "request_id" => govuk_request_id,
-          "some arg" => "some value",
-        },
-      ]
-    }
-
-    original_message = message.dup
+    expect(GdsApi::GovukHeaders).not_to receive(:set_header)
 
     described_class.new.call("worker", message, "queue") do
       expect(message).to eq(original_message)


### PR DESCRIPTION
The `GdsApi::GovukHeaders` header `x_govuk_authenticated_user` is used to identify the initiating user for an event, this should be made available to the Sidekiq worker job, so repopulate this header for downstream requests.