### PR TITLE
Ensure the initializer is required in the railtie

### DIFF
--- a/lib/govuk_sidekiq/railtie.rb
+++ b/lib/govuk_sidekiq/railtie.rb
@@ -1,3 +1,5 @@
+require "govuk_sidekiq/sidekiq_initializer"
+
 module GovukSidekiq
   class Railtie < Rails::Railtie
     initializer "govuk_sidekiq.initialize_sidekiq" do |app|

--- a/lib/govuk_sidekiq/version.rb
+++ b/lib/govuk_sidekiq/version.rb
@@ -1,3 +1,3 @@
 module GovukSidekiq
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
This was breaking before because the sidekiq_initializer file
hadn't been loaded before the railtie runs.