### PR TITLE
Add `govuk_sidekiq/testing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Add support for testing with `govuk_sidekiq/testing`
+
 # 0.0.1
 
 * Create a gem which automatically configures Sidekiq.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,22 @@
 Provides a unified set of configurations and behaviours when using Sidekiq
 in GOV.UK applications.
 
+## Usage
+
+### Testing
+
+See [Sidekiq testing documentation](https://github.com/mperham/sidekiq/wiki/Testing)
+on how to test Sidekiq workers.
+
+
+Because of the way we use middleware, you may see errors that indicate that
+your job is called with the wrong number invalid arguments. To set up testing
+correctly, replace `require 'sidekiq/testing'` with:
+
+```ruby
+require 'govuk_sidekiq/testing'
+```
+
 ## Technical documentation
 
 When added to a Rails application, this gem uses a railtie to inject an

--- a/lib/govuk_sidekiq/testing.rb
+++ b/lib/govuk_sidekiq/testing.rb
@@ -1,0 +1,5 @@
+require "sidekiq/testing"
+
+Sidekiq::Testing.server_middleware do |chain|
+  chain.add GovukSidekiq::APIHeaders::ServerMiddleware
+end


### PR DESCRIPTION
This is a replacement for `require "sidekiq/testing"`. It will require the sidekiq testing library and set up the testing middleware.

The way we use Sidekiq middleware is that `APIHeaders::ClientMiddleware` adds an extra argument to the job, and `APIHeaders::ServerMiddleware` removes it.

But Sidekiq by default does not load server middleware[1], which causes the extra argument to be added, but never removed. Sidekiq then calls the job with the extra argument, resulting in lots of `ArgumentError: wrong number of arguments (given 2, expected 1).`

[1] https://github.com/mperham/sidekiq/wiki/Testing#testing-server-middleware