### PR TITLE
Bump to version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.0
+
+* No changes. Version bump to indicate gem is stable.
+
 # 0.0.4
 
 * Add support for testing with `govuk_sidekiq/testing`

--- a/lib/govuk_sidekiq/version.rb
+++ b/lib/govuk_sidekiq/version.rb
@@ -1,3 +1,3 @@
 module GovukSidekiq
-  VERSION = "0.0.4"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
We're using this in production. To communicate that this gem is stable and will follow semantic versioning, we need to bump the version to 1.0.0.

(Also intended to test the webhooks/CI, which I hope I fixed).