### PR TITLE
Use redis url if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ worker: bundle exec sidekiq -C ./config/sidekiq.yml
 ### 4. Configure puppet
 
 - Set `REDIS_HOST` and `REDIS_PORT` variables. `GOVUK_APP_NAME` should also be
-set, but this is already done by the default `govuk::app::config`.
+set, but this is already done by the default `govuk::app::config`. If your Redis instance
+requires more advanced connection settings (eg username and password) you can instead
+set a `REDIS_URL` variable, this will take precidence over `REDIS_HOST` and `REDIS_PORT`.
 - Make sure puppet creates and starts the Procfile worker.
 
 There's no step-by-step guide for this, but [you can copy the config from collections-publisher](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/collections_publisher.pp).

--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rspec", "~> 3.4"
   spec.add_development_dependency "rake", "~> 11.1"
+  spec.add_development_dependency "railties", "~> 5.0.1"
 
   spec.add_development_dependency "bundler", ">= 1.10"
   spec.add_development_dependency "gem_publisher", "1.5.0"

--- a/lib/govuk_sidekiq/railtie.rb
+++ b/lib/govuk_sidekiq/railtie.rb
@@ -3,10 +3,18 @@ require "govuk_sidekiq/sidekiq_initializer"
 module GovukSidekiq
   class Railtie < Rails::Railtie
     initializer "govuk_sidekiq.initialize_sidekiq" do |app|
+      config = if ENV['REDIS_URL']
+                 { url: ENV['REDIS_URL'] }
+               else
+                 {
+                   host: ENV.fetch("REDIS_HOST", "127.0.0.1"),
+                   port: ENV.fetch("REDIS_PORT", 6379)
+                 }
+               end
+
       SidekiqInitializer.setup_sidekiq(
         ENV["GOVUK_APP_NAME"] || app.root.basename.to_s,
-        ENV["REDIS_HOST"] || "127.0.0.1",
-        ENV["REDIS_PORT"] || 6379
+        config
       )
     end
   end

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -6,13 +6,11 @@ require "govuk_sidekiq/api_headers"
 
 module GovukSidekiq
   module SidekiqInitializer
-    def self.setup_sidekiq(govuk_app_name, redis_host, redis_port)
-      redis_config = {
-        host: redis_host,
-        port: redis_port,
+    def self.setup_sidekiq(govuk_app_name, redis_config)
+      redis_config = redis_config.merge(
         namespace: govuk_app_name,
         reconnect_attempts: 1,
-      }
+      )
 
       Sidekiq.configure_server do |config|
         config.redis = redis_config

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+require 'rails'
+require 'govuk_sidekiq/railtie'
+
+RSpec.describe GovukSidekiq::Railtie do
+  let(:test_app) do
+    Class.new(Rails::Application) do
+      config.root = File.dirname(__FILE__)
+      config.eager_load = false
+
+      Rails.logger = config.logger = Logger.new(nil)
+    end
+  end
+  let(:app_name) { test_app.root.basename.to_s }
+
+  it 'loads the SidekiqInitializer with the default config' do
+    expected_config = { host: '127.0.0.1', port: 6379 }
+    expect(GovukSidekiq::SidekiqInitializer).to receive(:setup_sidekiq).with(app_name, expected_config)
+    test_app.initialize!
+  end
+
+  context 'when ENV contains REDIS_URL' do
+    let(:redis_url) { double }
+    before { stub_environment('REDIS_URL' => redis_url) }
+
+    it 'loads the SidekiqInitializer with the redis url' do
+      expected_config = { url: redis_url }
+      expect(GovukSidekiq::SidekiqInitializer).to receive(:setup_sidekiq).with(app_name, expected_config)
+      test_app.initialize!
+    end
+  end
+
+  context 'when ENV contains REDIS_HOST and REDIS_PORT' do
+    let(:redis_host) { double }
+    let(:redis_port) { double }
+    before { stub_environment('REDIS_HOST' => redis_host, 'REDIS_PORT' => redis_port) }
+
+    it 'loads the SidekiqInitializer with supplied details' do
+      expected_config = { host: redis_host, port: redis_port }
+      expect(GovukSidekiq::SidekiqInitializer).to receive(:setup_sidekiq).with(app_name, expected_config)
+      test_app.initialize!
+    end
+  end
+
+  def stub_environment(values)
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:fetch).and_call_original
+
+    values.each do |key, value|
+      allow(ENV).to receive(:[]).with(key).and_return(value)
+      allow(ENV).to receive(:fetch).with(key, anything).and_return(value)
+    end
+  end
+end

--- a/spec/sidekiq_initializer_spec.rb
+++ b/spec/sidekiq_initializer_spec.rb
@@ -3,6 +3,6 @@ require "govuk_sidekiq/sidekiq_initializer"
 
 RSpec.describe GovukSidekiq::SidekiqInitializer do
   it "doesn't explode when called" do
-    described_class.setup_sidekiq("govuk_app_name", "redis_host", 12345)
+    described_class.setup_sidekiq("govuk_app_name", host: "redis_host", port: 12345)
   end
 end


### PR DESCRIPTION
This allows us to configure out Redis instance on Heroku which requires an username and password and automatically provide a `REDIS_URL` to do this.