### PR TITLE
Configure Sidekiq to reconnect to Redis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.3
+
+* Explicitly set `reconnect_attempts: 1` in client and server configuration,
+  to fix Sidekiq regression.
+
 # 1.0.2
 
 * Upgrade to Sidekiq 4.2.8.

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -11,6 +11,7 @@ module GovukSidekiq
         host: redis_host,
         port: redis_port,
         namespace: govuk_app_name,
+        reconnect_attempts: 1,
       }
 
       Sidekiq.configure_server do |config|

--- a/lib/govuk_sidekiq/version.rb
+++ b/lib/govuk_sidekiq/version.rb
@@ -1,3 +1,3 @@
 module GovukSidekiq
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end


### PR DESCRIPTION
This fixes a regression in Sidekiq 4.2.8, which caused frequent
ECONNRESET errors. The default will probably be restored in a future
Sidekiq release, in which case we can bump the version and revert this
change.