### PR TITLE
Make step to add redis vars more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ See the [Pinfile](https://github.gds/gds/development/blob/master/Pinfile) and
 
 ### 7. Add app to sidekiq-monitoring
 
-See the opsmanual for a step-by-step guide: [HOWTO: Add sidekiq-monitoring to your application](https://github.gds/pages/gds/opsmanual/infrastructure/howto/setting-up-new-sidekiq-monitoring-app.html)
+See the opsmanual for a step-by-step guide: [HOWTO: Add sidekiq-monitoring to your application](https://docs.publishing.service.gov.uk/manual/setting-up-new-sidekiq-monitoring-app.html)
 
 ### 8. Create some jobs
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ worker: bundle exec sidekiq -C ./config/sidekiq.yml
 set, but this is already done by the default `govuk::app::config`. If your Redis instance
 requires more advanced connection settings (eg username and password) you can instead
 set a `REDIS_URL` variable, this will take precidence over `REDIS_HOST` and `REDIS_PORT`.
+
+    Apply redis variables for your app in [the default config](https://github.com/alphagov/govuk-puppet/blob/master/hieradata/common.yaml). For example:
+    
+    ```
+    govuk::apps::your_app::redis_host: "%{hiera('sidekiq_host')}"
+    govuk::apps::your_app::redis_port: "%{hiera('sidekiq_port')}"
+    ```
 - Make sure puppet creates and starts the Procfile worker.
 
 There's no step-by-step guide for this, but [you can copy the config from collections-publisher](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/collections_publisher.pp).


### PR DESCRIPTION
Adds more detailed explanation for step on defining redis variables when
configuring for Puppet. This was missed as a step when we were setting
our app up.

Also fixes a broken link.