### PR TITLE
Remove automatic integration with Airbrake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Unreleased
+
+* BREAKING. Remove automatic integration with Airbrake, as we are moving to use Sentry. To keep using this gem with Airbrake you can still add the following to an initialiser:
+
+```ruby
+require 'airbrake'
+
+Sidekiq.configure_server do |config|
+  config.error_handlers << Proc.new { |ex, context_hash| Airbrake.notify(ex, context_hash) }
+end
+```
+
 # 1.0.3
 
 * Explicitly set `reconnect_attempts: 1` in client and server configuration,

--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sidekiq-statsd", "~> 0.1"
   spec.add_dependency "sidekiq-logging-json", "~> 0.0"
   spec.add_dependency "gds-api-adapters", ">= 19.1.0"
-  spec.add_dependency "airbrake", ">= 3.1.0"
   spec.add_dependency "redis-namespace", "~> 1.5.2"
 
   spec.add_development_dependency "rspec", "~> 3.4"

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -1,7 +1,6 @@
 require "sidekiq"
 require "sidekiq/logging/json"
 require "sidekiq-statsd"
-require "airbrake"
 require "govuk_sidekiq/api_headers"
 
 module GovukSidekiq
@@ -14,7 +13,6 @@ module GovukSidekiq
 
       Sidekiq.configure_server do |config|
         config.redis = redis_config
-        config.error_handlers << Proc.new { |ex, context_hash| Airbrake.notify(ex, context_hash) }
 
         config.server_middleware do |chain|
           chain.add Sidekiq::Statsd::ServerMiddleware, env: "govuk.app.#{govuk_app_name}", prefix: "workers"


### PR DESCRIPTION
We are moving to Sentry, which has its own integration with Sidekiq baked into the client. This means we don't have to send the errors manually anymore.

Breaking change because without remedy apps will stop sending Airbrake messages.

https://trello.com/c/iKDvE6Gd