### PR TITLE
Use GovukStatsd 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Unreleased
+
+* BREAKING. Your statsd namespace will likely change with this version, to a
+form of `govuk.app.<app_name>.<hostname>` unless you are already using
+the `GOVUK_STATSD_PREFIX` environment variable for your statsd.
+
+* Loosen dependencies, now will support Sidekiq 5
+* Introduce dependency on [govuk_app_config](https://github.com/alphagov/govuk_app_config)
+* Use GovukStatsd as the statsd client for sidekiq-statsd
+
 # 2.0.0
 
 * BREAKING. Remove automatic integration with Airbrake, as we are moving to use Sentry. To keep using this gem with Airbrake you can still add the following to an initialiser:

--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -19,15 +19,16 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.2"
 
-  spec.add_dependency "sidekiq", "~> 4.2.8"
+  spec.add_dependency "sidekiq", ">= 5", "< 6"
   spec.add_dependency "sidekiq-statsd", "~> 0.1"
   spec.add_dependency "sidekiq-logging-json", "~> 0.0"
   spec.add_dependency "gds-api-adapters", ">= 19.1.0"
-  spec.add_dependency "redis-namespace", "~> 1.5.2"
+  spec.add_dependency "redis-namespace", "~> 1.6"
+  spec.add_dependency "govuk_app_config", ">= 1.1"
 
   spec.add_development_dependency "rspec", "~> 3.4"
-  spec.add_development_dependency "rake", "~> 11.1"
-  spec.add_development_dependency "railties", "~> 5.0.1"
+  spec.add_development_dependency "rake", "~> 12.3"
+  spec.add_development_dependency "railties", "~> 5.0"
 
   spec.add_development_dependency "bundler", ">= 1.10"
 end

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -2,6 +2,7 @@ require "sidekiq"
 require "sidekiq/logging/json"
 require "sidekiq-statsd"
 require "govuk_sidekiq/api_headers"
+require "govuk_app_config/govuk_statsd"
 
 module GovukSidekiq
   module SidekiqInitializer
@@ -15,7 +16,7 @@ module GovukSidekiq
         config.redis = redis_config
 
         config.server_middleware do |chain|
-          chain.add Sidekiq::Statsd::ServerMiddleware, env: "govuk.app.#{govuk_app_name}", prefix: "workers"
+          chain.add Sidekiq::Statsd::ServerMiddleware, statsd: GovukStatsd, env: nil, prefix: "workers"
           chain.add GovukSidekiq::APIHeaders::ServerMiddleware
         end
       end

--- a/lib/govuk_sidekiq/testing.rb
+++ b/lib/govuk_sidekiq/testing.rb
@@ -1,4 +1,5 @@
 require "sidekiq/testing"
+require "govuk_sidekiq/api_headers"
 
 Sidekiq::Testing.server_middleware do |chain|
   chain.add GovukSidekiq::APIHeaders::ServerMiddleware

--- a/spec/integration/check_a_sidekiq_worker_can_perform_spec.rb
+++ b/spec/integration/check_a_sidekiq_worker_can_perform_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+require "govuk_sidekiq/testing"
+require "govuk_sidekiq/sidekiq_initializer"
+
+RSpec.describe "Check a Sidekiq Worker can perform" do
+
+  class TestWorker
+    include Sidekiq::Worker
+
+    def perform(arg)
+      arg + 1
+    end
+  end
+
+  before do
+    GovukSidekiq::SidekiqInitializer.setup_sidekiq("test_app", {})
+  end
+
+  it "can run the test worker" do
+    expect {
+      Sidekiq::Testing.fake! do
+        TestWorker.perform_async(1)
+        TestWorker.drain
+      end
+    }.not_to raise_error
+  end
+
+end


### PR DESCRIPTION
In my little mission to improve consistency with how we approach statsd this changes this gem to use GovukStatsd as the statsd client.

This also loosens up some dependencies so that this can support sidekiq 5.

Prior to merging I'll install this into an app to check it works.