### PR TITLE
Add a middleware to raise a special exception if the job is retried

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Raise a special `RetryableError` exception if the worker is due to be retried. This means
+  you can ignore this exception in your error reporting.
+
 # 3.0.0
 
 * BREAKING. Your statsd namespace will likely change with this version, to a

--- a/lib/govuk_sidekiq/error_handling.rb
+++ b/lib/govuk_sidekiq/error_handling.rb
@@ -1,0 +1,58 @@
+require "gds_api/exceptions"
+require "sidekiq/job_retry"
+
+module GovukSidekiq
+  module ErrorHandling
+    class RetryableError < StandardError; end
+
+    class RetryWithoutAlertMiddleware
+      DEFAULT_EXCEPTIONS = [
+        GdsApi::HTTPClientError,
+      ].freeze
+
+      def initialize(extra_exceptions = [])
+        @extra_exceptions = extra_exceptions
+      end
+
+      attr_reader :extra_exceptions
+
+      def call(worker, msg, queue)
+        yield
+      rescue *exceptions_to_catch
+        if should_raise_real_exception?(msg)
+          raise
+        else
+          raise RetryableError
+        end
+      end
+
+      def exceptions_to_catch
+        DEFAULT_EXCEPTIONS + extra_exceptions
+      end
+
+      def does_retry?(msg)
+        msg["retry"]
+      end
+
+      def max_retries(msg)
+        if msg["retry"].is_a?(Integer)
+          msg["retry"]
+        else
+          Sidekiq::JobRetry::DEFAULT_MAX_RETRY_ATTEMPTS
+        end
+      end
+
+      def retry_count(msg)
+        msg["retry_count"] || 0
+      end
+
+      def last_try?(msg)
+        retry_count(msg) == max_retries(msg) - 1
+      end
+
+      def should_raise_real_exception?(msg)
+        !does_retry?(msg) || last_try?(msg)
+      end
+    end
+  end
+end

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -18,6 +18,7 @@ module GovukSidekiq
         config.server_middleware do |chain|
           chain.add Sidekiq::Statsd::ServerMiddleware, statsd: GovukStatsd, env: nil, prefix: "workers"
           chain.add GovukSidekiq::APIHeaders::ServerMiddleware
+          chain.add GovukSidekiq::ErrorHandling::RetryWithoutAlertMiddleware
         end
       end
 

--- a/lib/govuk_sidekiq/testing.rb
+++ b/lib/govuk_sidekiq/testing.rb
@@ -3,4 +3,5 @@ require "govuk_sidekiq/api_headers"
 
 Sidekiq::Testing.server_middleware do |chain|
   chain.add GovukSidekiq::APIHeaders::ServerMiddleware
+  chain.add GovukSidekiq::ErrorHandling::RetryWithoutAlertMiddleware
 end

--- a/spec/error_handling_spec.rb
+++ b/spec/error_handling_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+require "govuk_sidekiq/error_handling"
+
+RSpec.describe GovukSidekiq::ErrorHandling::RetryWithoutAlertMiddleware do
+  def worker
+    raise GdsApi::HTTPClientError.new("oh no")
+  end
+
+  subject do
+    described_class.new.call("worker", msg, "queue") { worker }
+  end
+
+  context "when the job is on the last attempt" do
+    let(:msg) do
+      {
+        "retry" => 5,
+        "retry_count" => 4,
+      }
+    end
+
+    it "raises the real exception" do
+      expect { subject }.to raise_error(GdsApi::HTTPClientError)
+    end
+  end
+
+  context "when the job is not on the last attempt" do
+    let(:msg) do
+      {
+        "retry" => 5,
+        "retry_count" => 1,
+      }
+    end
+
+    it "raises the retry exception" do
+      expect { subject }.to raise_error(GovukSidekiq::ErrorHandling::RetryableError)
+    end
+  end
+
+  context "when the job is not on the last attempt and it has the default max attempts" do
+    let(:msg) do
+      {
+        "retry" => true,
+        "retry_count" => 1,
+      }
+    end
+
+    it "raises the retry exception" do
+      expect { subject }.to raise_error(GovukSidekiq::ErrorHandling::RetryableError)
+    end
+  end
+end


### PR DESCRIPTION
This makes it easier to filter out exceptions that occur but succeed in the next retry. The next part of this will be to configure `govuk_app_config` to ignore the new `RetryWorker` exception.

Currently we get a lot of errors from Sidekiq in Sentry when the job itself succeeds on the second or third so we don't really need to see these errors. This is especially prominent in [Publishing API](https://trello.com/c/Zslgi9sV/347-quieten-down-the-downstream-errors) and [Link Checker API](https://github.com/alphagov/link-checker-api/blob/master/app/workers/webhook_worker.rb#L36).

This does pose a problem where we may not see errors quick enough if a job takes 21 days to eventually fail, so an alternative might be to start showing errors after 2 or 3 retries.