### PR TITLE
Check if the job needs header arguments before appending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+* Do not add API middleware arguments if they already exist.
+
 # 3.0.0
 
 * BREAKING. Your statsd namespace will likely change with this version, to a

--- a/spec/api_headers_spec.rb
+++ b/spec/api_headers_spec.rb
@@ -35,6 +35,19 @@ RSpec.describe GovukSidekiq::APIHeaders::ClientMiddleware do
       expect(job["args"].last[:authenticated_user]).to eq(preexisting_authenticated_user)
     end
   end
+
+  it "doesn't adds the govuk_request_id and govuk_authenticated_user to the job arguments if they are nil" do
+    GdsApi::GovukHeaders.set_header(:govuk_request_id, nil)
+    GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, nil)
+
+    job = {
+      "args" => []
+    }
+
+    described_class.new.call("worker_class", job, "queue", "redis_pool") do
+      expect(job["args"]).to eq([])
+    end
+  end
 end
 
 RSpec.describe GovukSidekiq::APIHeaders::ServerMiddleware do


### PR DESCRIPTION
Sometimes when a job is run it gets the header arguments twice, which causes the worker to fail with the incorrect number of arguments (as the server middleware only removes one set).  In all cases the extra arguments seem to be `null`, so just don't append if we would add null things, or they are already there.

Hopefully fixes #37

---

[Trello card](https://trello.com/c/SRnVqyIm/289-investigate-asset-manager-edge-cases)