### PR TITLE
Point gemspec to LICENCE file

### DIFF
--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://github.com/alphagov/govuk_sidekiq"
   spec.license       = "MIT"
 
-  spec.files         = Dir.glob("lib/**/*") + %w(README.md LICENCE.txt)
+  spec.files         = Dir.glob("lib/**/*") + %w(README.md LICENCE)
   spec.test_files    = Dir.glob("test/**/*")
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
"LICENCE.txt" is not a file, so the gemspec is invalid:

```
+ gem build govuk_sidekiq.gemspec
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["LICENCE.txt"] are not files
```

gemspec is valid now:

```
vagrant@development:/var/govuk/govuk_sidekiq$ gem build govuk_sidekiq.gemspec
WARNING:  open-ended dependency on gds-api-adapters (>= 19.1.0) is not recommended
  if gds-api-adapters is semantically versioned, use:
    add_runtime_dependency 'gds-api-adapters', '~> 19.1', '>= 19.1.0'
WARNING:  open-ended dependency on govuk_app_config (>= 1.1) is not recommended
  if govuk_app_config is semantically versioned, use:
    add_runtime_dependency 'govuk_app_config', '~> 1.1'
WARNING:  open-ended dependency on bundler (>= 1.10, development) is not recommended
  if bundler is semantically versioned, use:
    add_development_dependency 'bundler', '~> 1.10'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: govuk_sidekiq
  Version: 3.0.1
  File: govuk_sidekiq-3.0.1.gem
```