### PR TITLE
Only ensure the request_id parameter is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+* Set the `request_id` even if the `govuk_authenticated_user` is missing, and vice versa.
+
 # 3.0.1
 
 * Do not add API middleware arguments if they already exist.

--- a/lib/govuk_sidekiq/api_headers.rb
+++ b/lib/govuk_sidekiq/api_headers.rb
@@ -10,7 +10,10 @@ module GovukSidekiq
       def call(worker_class, job, queue, redis_pool)
         last_arg = job["args"].last
 
-        if needs_headers(last_arg)
+        if is_header_hash(last_arg)
+          job["args"].pop
+          job["args"] << header_arguments.merge(last_arg)
+        else
           job["args"] << header_arguments
         end
 
@@ -24,9 +27,8 @@ module GovukSidekiq
         }
       end
 
-      def needs_headers(last_arg)
-        has_args = last_arg.is_a?(Hash) && last_arg.symbolize_keys.keys.include?(:authenticated_user) && last_arg.symbolize_keys.keys.include?(:request_id)
-        !has_args && header_arguments[:authenticated_user].present? && header_arguments[:request_id].present?
+      def is_header_hash(arg)
+        arg.is_a?(Hash) && (arg.symbolize_keys.keys.include?(:authenticated_user) || arg.symbolize_keys.keys.include?(:request_id))
       end
     end
 


### PR DESCRIPTION
Judging from test failures with 3.0.1, it looks like `authenticated_user` is optional.  So if the `authenticated_user` is not present, we should still set the `request_id`.

Example test failures:

- [manuals-publisher](https://ci.integration.publishing.service.gov.uk/job/manuals-publisher/job/dependabot%252Fbundler%252Fgovuk_sidekiq-3.0.1/1/)
- [publishing-api](https://ci.integration.publishing.service.gov.uk/job/publishing-api/job/dependabot%252Fbundler%252Fgovuk_sidekiq-3.0.1/1/)
- [publisher](https://ci.integration.publishing.service.gov.uk/job/publisher/job/dependabot%252Fbundler%252Fgovuk_sidekiq-3.0.1/1/)

---

[Trello card](https://trello.com/c/SRnVqyIm/289-investigate-asset-manager-edge-cases)