### PR TITLE
Only use JSON logging when there is a log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Only use JSON logging when a log file is specified
+
 # 3.0.2
 
 * Set the `request_id` even if the `govuk_authenticated_user` is missing, and vice versa.

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -29,7 +29,7 @@ module GovukSidekiq
         end
       end
 
-      Sidekiq.logger.formatter = Sidekiq::Logging::Json::Logger.new
+      Sidekiq.logger.formatter = Sidekiq::Logging::Json::Logger.new if Sidekiq.options[:logfile]
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/rXTLvzSu/753-scheduling-is-sent-to-the-publishing-api

This makes for much easier to read logs when Sidekiq is outputting to
stdout.

Before:

```
➜  content-publisher git:(master) foreman start worker -f Procfile.dev
20:26:59 worker.1 | started with pid 36593
20:27:03 worker.1 | 2019-03-04T20:27:03.080Z 36593 TID-oxc1r39cx INFO: Booting Sidekiq 5.2.5 with redis options {:host=>"127.0.0.1", :port=>6379, :namespace=>"content-publisher", :reconnect_attempts=>1, :id=>"Sidekiq-server-PID-36593", :url=>nil}
20:27:03 worker.1 | {"@timestamp":"2019-03-04T20:27:03Z","@fields":{"pid":36593,"tid":"TID-oxc1r2mz4","context":"","program_name":null,"worker":null},"@type":"sidekiq","@status":null,"@severity":"INFO","@run_time":null,"@message":"Running in ruby 2.6.1p33 (2019-01-30 revision 66950) [x86_64-darwin17]"}
20:27:03 worker.1 | {"@timestamp":"2019-03-04T20:27:03Z","@fields":{"pid":36593,"tid":"TID-oxc1r2mz4","context":"","program_name":null,"worker":null},"@type":"sidekiq","@status":null,"@severity":"INFO","@run_time":null,"@message":"See LICENSE and the LGPL-3.0 for licensing details."}
20:27:03 worker.1 | {"@timestamp":"2019-03-04T20:27:03Z","@fields":{"pid":36593,"tid":"TID-oxc1r2mz4","context":"","program_name":null,"worker":null},"@type":"sidekiq","@status":null,"@severity":"INFO","@run_time":null,"@message":"Upgrade to Sidekiq Pro for more features and support: http://sidekiq.org"}
20:27:03 worker.1 | {"@timestamp":"2019-03-04T20:27:03Z","@fields":{"pid":36593,"tid":"TID-oxc1r2mz4","context":"","program_name":null,"worker":null},"@type":"sidekiq","@status":null,"@severity":"INFO","@run_time":null,"@message":"Starting processing, hit Ctrl-C to stop"}
^C20:27:07 system   | SIGINT received, starting shutdown
20:27:07 worker.1 | {"@timestamp":"2019-03-04T20:27:07Z","@fields":{"pid":36593,"tid":"TID-oxc1r2mz4","context":"","program_name":null,"worker":null},"@type":"sidekiq","@status":null,"@severity":"INFO","@run_time":null,"@message":"Shutting down"}
20:27:07 worker.1 | {"@timestamp":"2019-03-04T20:27:07Z","@fields":{"pid":36593,"tid":"TID-oxc1r2mz4","context":"","program_name":null,"worker":null},"@type":"sidekiq","@status":null,"@severity":"INFO","@run_time":null,"@message":"Terminating quiet workers"}
20:27:07 worker.1 | {"@timestamp":"2019-03-04T20:27:07Z","@fields":{"pid":36593,"tid":"TID-oxc1rzsic","context":"","program_name":null,"worker":null},"@type":"sidekiq","@status":null,"@severity":"INFO","@run_time":null,"@message":"Scheduler exiting..."}
20:27:07 system   | sending SIGTERM to all processes
20:27:08 worker.1 | {"@timestamp":"2019-03-04T20:27:08Z","@fields":{"pid":36593,"tid":"TID-oxc1r2mz4","context":"","program_name":null,"worker":null},"@type":"sidekiq","@status":null,"@severity":"INFO","@run_time":null,"@message":"Pausing to allow workers to finish..."}
20:27:08 worker.1 | {"@timestamp":"2019-03-04T20:27:08Z","@fields":{"pid":36593,"tid":"TID-oxc1r2mz4","context":"","program_name":null,"worker":null},"@type":"sidekiq","@status":null,"@severity":"INFO","@run_time":null,"@message":"Bye!"}
20:27:08 worker.1 | exited with code 0
```

After:

```
➜  content-publisher git:(master) foreman start worker -f Procfile.dev
20:26:08 worker.1 | started with pid 36488
20:26:12 worker.1 | 2019-03-04T20:26:12.457Z 36488 TID-owh5bs39c INFO: Booting Sidekiq 5.2.5 with redis options {:host=>"127.0.0.1", :port=>6379, :namespace=>"content-publisher", :reconnect_attempts=>1, :id=>"Sidekiq-server-PID-36488", :url=>nil}
20:26:13 worker.1 | 2019-03-04T20:26:13.015Z 36488 TID-owh5bs39c INFO: Running in ruby 2.6.1p33 (2019-01-30 revision 66950) [x86_64-darwin17]
20:26:13 worker.1 | 2019-03-04T20:26:13.015Z 36488 TID-owh5bs39c INFO: See LICENSE and the LGPL-3.0 for licensing details.
20:26:13 worker.1 | 2019-03-04T20:26:13.015Z 36488 TID-owh5bs39c INFO: Upgrade to Sidekiq Pro for more features and support: http://sidekiq.org
20:26:13 worker.1 | 2019-03-04T20:26:13.021Z 36488 TID-owh5bs39c INFO: Starting processing, hit Ctrl-C to stop
^C20:26:16 system   | SIGINT received, starting shutdown
20:26:16 worker.1 | 2019-03-04T20:26:16.942Z 36488 TID-owh5bs39c INFO: Shutting down
20:26:16 worker.1 | 2019-03-04T20:26:16.943Z 36488 TID-owh5bs39c INFO: Terminating quiet workers
20:26:16 worker.1 | 2019-03-04T20:26:16.943Z 36488 TID-owh6dfkuk INFO: Scheduler exiting...
20:26:17 worker.1 | 2019-03-04T20:26:17.447Z 36488 TID-owh5bs39c INFO: Pausing to allow workers to finish...
20:26:17 system   | sending SIGTERM to all processes
20:26:17 worker.1 | 2019-03-04T20:26:17.951Z 36488 TID-owh5bs39c INFO: Bye!
20:26:18 worker.1 | exited with code 0
```