### PR TITLE
Remove REDIS_HOST/REDIS_PORT configuration appraoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 5.0.0
 
 * BREAKING: Redis is configured with REDIS_URL environment, the previous approach (REDIS_HOST and REDIS_PORT) is no longer supported.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* BREAKING: Redis is configured with REDIS_URL environment, the previous approach (REDIS_HOST and REDIS_PORT) is no longer supported.
+
 # 4.0.0
 
 * BREAKING: Set the required Ruby version to >= 2.6

--- a/README.md
+++ b/README.md
@@ -50,10 +50,8 @@ worker: bundle exec sidekiq -C ./config/sidekiq.yml
 
 ### 4. Configure puppet
 
-- Set `REDIS_HOST` and `REDIS_PORT` variables. `GOVUK_APP_NAME` should also be
-set, but this is already done by the default `govuk::app::config`. If your Redis instance
-requires more advanced connection settings (eg username and password) you can instead
-set a `REDIS_URL` variable, this will take precidence over `REDIS_HOST` and `REDIS_PORT`.
+- Set a `REDIS_URL` environment variable. `GOVUK_APP_NAME` should also be
+set, but this is already done by the default `govuk::app::config`.
 
     Apply redis variables for your app in [the default config](https://github.com/alphagov/govuk-puppet/blob/master/hieradata/common.yaml). For example:
 

--- a/lib/govuk_sidekiq/railtie.rb
+++ b/lib/govuk_sidekiq/railtie.rb
@@ -3,18 +3,9 @@ require "govuk_sidekiq/sidekiq_initializer"
 module GovukSidekiq
   class Railtie < Rails::Railtie
     initializer "govuk_sidekiq.initialize_sidekiq" do |app|
-      config = if ENV["REDIS_URL"]
-                 { url: ENV["REDIS_URL"] }
-               else
-                 {
-                   host: ENV.fetch("REDIS_HOST", "127.0.0.1"),
-                   port: ENV.fetch("REDIS_PORT", 6379),
-                 }
-               end
-
       SidekiqInitializer.setup_sidekiq(
         ENV["GOVUK_APP_NAME"] || app.root.basename.to_s,
-        config,
+        { url: ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379") },
       )
     end
   end

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -6,7 +6,7 @@ require "govuk_app_config/govuk_statsd"
 
 module GovukSidekiq
   module SidekiqInitializer
-    def self.setup_sidekiq(govuk_app_name, redis_config)
+    def self.setup_sidekiq(govuk_app_name, redis_config = {})
       redis_config = redis_config.merge(
         namespace: govuk_app_name,
         reconnect_attempts: 1,

--- a/lib/govuk_sidekiq/version.rb
+++ b/lib/govuk_sidekiq/version.rb
@@ -1,3 +1,3 @@
 module GovukSidekiq
-  VERSION = "4.0.0".freeze
+  VERSION = "5.0.0".freeze
 end

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe GovukSidekiq::Railtie do
   let(:app_name) { test_app.root.basename.to_s }
 
   it "loads the SidekiqInitializer with the default config" do
-    expected_config = { host: "127.0.0.1", port: 6379 }
+    expected_config = { url: "redis://127.0.0.1:6379" }
     expect(GovukSidekiq::SidekiqInitializer).to receive(:setup_sidekiq).with(app_name, expected_config)
     test_app.initialize!
   end
@@ -25,18 +25,6 @@ RSpec.describe GovukSidekiq::Railtie do
 
     it "loads the SidekiqInitializer with the redis url" do
       expected_config = { url: redis_url }
-      expect(GovukSidekiq::SidekiqInitializer).to receive(:setup_sidekiq).with(app_name, expected_config)
-      test_app.initialize!
-    end
-  end
-
-  context "when ENV contains REDIS_HOST and REDIS_PORT" do
-    let(:redis_host) { double }
-    let(:redis_port) { double }
-    before { stub_environment("REDIS_HOST" => redis_host, "REDIS_PORT" => redis_port) }
-
-    it "loads the SidekiqInitializer with supplied details" do
-      expected_config = { host: redis_host, port: redis_port }
       expect(GovukSidekiq::SidekiqInitializer).to receive(:setup_sidekiq).with(app_name, expected_config)
       test_app.initialize!
     end

--- a/spec/sidekiq_initializer_spec.rb
+++ b/spec/sidekiq_initializer_spec.rb
@@ -3,6 +3,6 @@ require "govuk_sidekiq/sidekiq_initializer"
 
 RSpec.describe GovukSidekiq::SidekiqInitializer do
   it "doesn't explode when called" do
-    described_class.setup_sidekiq("govuk_app_name", host: "redis_host", port: 12_345)
+    described_class.setup_sidekiq("govuk_app_name", { url: "redis://redis" })
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/dXud4WIt/206-inconsistent-redisurl-config

This settles on REDIS_URL as the means to configure this gem, this was
chosen as it is one natively understood by the Redis gem [1] and thus
more common.

This choice has been removed as part of a GOV.UK effort to remove the
confusion that can be caused by having two different configuration
approaches used across the platform.

It also updates the SidekiqInitializer#setup_sidekiq method to not
require a redis config since this is not necessarily needed when
REDIS_URL is set (the Redis gem will pick this up automatically).

[1]: https://github.com/redis/redis-rb