### PR TITLE
Revert "Only allow logging through stdout"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# 6.0.0-pre
-
-* BREAKING: Logging is now handled using stdout, this is in preparation for an upgrade to sidekiq version 6.0 which doesn't support logging to JSON files. Really, really breaking, govuk apps don't support this at all, only releasing because we can't replicate the logging behaviour locally and we need to test things. Do not upgrade to this version.
-
 # 5.0.0
 
 * BREAKING: Redis is configured with REDIS_URL environment, the previous approach (REDIS_HOST and REDIS_PORT) is no longer supported.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ What does `govuk_sidekiq` do for you?
 2. Makes sure that the correct HTTP headers are passed on to [gds-api-adapters](https://github.com/alphagov/gds-api-adapters).
  This means that for each request a unique ID (`govuk_request_id`) will be passed on to downstream applications.
  [Read more about request tracing][req-tracing].
-3. Sends activity stats to Statsd, so that you can make pretty graphs of activity
+3. Makes sure that we use JSON logging, so that Sidekiq logs will end up
+ properly in Kibana.
+4. Sends activity stats to Statsd, so that you can make pretty graphs of activity
  in Grafana or Graphite. See the [Rummager dashboards for an example](https://grafana.publishing.service.gov.uk/dashboard/file/rummager_queues.json).
 
 [req-tracing]: https://docs.publishing.service.gov.uk/manual/setting-up-request-tracing.html

--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "govuk_app_config", ">= 1.1"
   spec.add_dependency "redis-namespace", "~> 1.6"
   spec.add_dependency "sidekiq", ">= 5", "< 6"
+  spec.add_dependency "sidekiq-logging-json", "~> 0.0"
   spec.add_dependency "sidekiq-statsd", ">= 2.1"
 
   spec.add_development_dependency "railties", "~> 5.0"

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -1,4 +1,5 @@
 require "sidekiq"
+require "sidekiq/logging/json"
 require "sidekiq-statsd"
 require "govuk_sidekiq/api_headers"
 require "govuk_app_config/govuk_statsd"
@@ -28,7 +29,7 @@ module GovukSidekiq
         end
       end
 
-      Sidekiq.logger = Logger.new($stdout)
+      Sidekiq.logger.formatter = Sidekiq::Logging::Json::Logger.new if Sidekiq.options[:logfile]
     end
   end
 end

--- a/lib/govuk_sidekiq/version.rb
+++ b/lib/govuk_sidekiq/version.rb
@@ -1,3 +1,3 @@
 module GovukSidekiq
-  VERSION = "6.0.0-pre".freeze
+  VERSION = "5.0.0".freeze
 end


### PR DESCRIPTION
Reverts alphagov/govuk_sidekiq#54

Turns out you can use branches of gems rather than having to do this somewhat nuclear option. This reverts the changes until they're ready.