### PR TITLE
Version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Unreleased
+# 6.0.0
+* BREAKING: Upgrades the underlying version of Sidekiq to version 6. Will require changes to logging strategy;
 
-* Change Sidekiq dependency to "~> 5" rather than ">= 5, < 6" to ensure Sidekiq 6 pre-releases aren't installed.
+* Sidekiq arguments need to serialize safely to JSON otherwise [a warning is shown](https://github.com/mperham/sidekiq/blob/main/Changes.md#640)
+* Logging to a file no longer supported, must use STDOUT or STDERR
 
 # 5.0.0
 

--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gds-api-adapters", ">= 19.1.0"
   spec.add_dependency "govuk_app_config", ">= 1.1"
   spec.add_dependency "redis-namespace", "~> 1.6"
-  spec.add_dependency "sidekiq", "~> 5"
-  spec.add_dependency "sidekiq-logging-json", "~> 0.0"
+  spec.add_dependency "sidekiq", "~> 6"
   spec.add_dependency "sidekiq-statsd", ">= 2.1"
 
   spec.add_development_dependency "climate_control", "~> 1.2"

--- a/lib/govuk_sidekiq/api_headers.rb
+++ b/lib/govuk_sidekiq/api_headers.rb
@@ -22,8 +22,8 @@ module GovukSidekiq
 
       def header_arguments
         {
-          authenticated_user: GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user],
-          request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
+          "authenticated_user" => GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user],
+          "request_id" => GdsApi::GovukHeaders.headers[:govuk_request_id],
         }
       end
 

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -1,5 +1,4 @@
 require "sidekiq"
-require "sidekiq/logging/json"
 require "sidekiq-statsd"
 require "govuk_sidekiq/api_headers"
 require "govuk_app_config/govuk_statsd"
@@ -13,6 +12,8 @@ module GovukSidekiq
       )
 
       Sidekiq.configure_server do |config|
+        config.log_formatter = Sidekiq::Logger::Formatters::JSON.new
+
         config.redis = redis_config
 
         config.server_middleware do |chain|
@@ -28,8 +29,6 @@ module GovukSidekiq
           chain.add GovukSidekiq::APIHeaders::ClientMiddleware
         end
       end
-
-      Sidekiq.logger.formatter = Sidekiq::Logging::Json::Logger.new if Sidekiq.options[:logfile]
     end
   end
 end

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -12,7 +12,7 @@ module GovukSidekiq
       )
 
       Sidekiq.configure_server do |config|
-        config.log_formatter = Sidekiq::Logger::Formatters::JSON.new
+        config.log_formatter = Sidekiq::Logger::Formatters::JSON.new if ENV["GOVUK_SIDEKIQ_JSON_LOGGING"]
 
         config.redis = redis_config
 

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -14,6 +14,15 @@ module GovukSidekiq
       Sidekiq.configure_server do |config|
         config.log_formatter = Sidekiq::Logger::Formatters::JSON.new if ENV["GOVUK_SIDEKIQ_JSON_LOGGING"]
 
+        # $real_stdout is defined by govuk_app_config and is used to point to
+        # STDOUT as that redirects $stdout to actually be $stderr.
+        # When govuk_app_config does this we need to use $real_stdout to output logs to STDOUT.
+        # https://github.com/alphagov/govuk_app_config/blob/08fd9cf6a848615261b3cef021e34490ed72ee55/lib/govuk_app_config/govuk_logging.rb#L18-L24
+
+        # rubocop:disable Style/GlobalVars
+        config.logger = Sidekiq::Logger.new($real_stdout) if defined?($real_stdout)
+        # rubocop:enable Style/GlobalVars
+
         config.redis = redis_config
 
         config.server_middleware do |chain|

--- a/spec/govuk_sidekiq/api_headers_spec.rb
+++ b/spec/govuk_sidekiq/api_headers_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe GovukSidekiq::APIHeaders do
       }
 
       described_class.new.call("worker_class", job, "queue", "redis_pool") do
-        expect(job["args"].last[:request_id]).to eq(govuk_request_id)
-        expect(job["args"].last[:authenticated_user]).to eq(govuk_authenticated_user)
+        expect(job["args"].last["request_id"]).to eq(govuk_request_id)
+        expect(job["args"].last["authenticated_user"]).to eq(govuk_authenticated_user)
       end
     end
 
@@ -27,12 +27,12 @@ RSpec.describe GovukSidekiq::APIHeaders do
       GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, govuk_authenticated_user)
 
       job = {
-        "args" => [{ authenticated_user: preexisting_authenticated_user, request_id: preexisting_request_id }],
+        "args" => [{ "authenticated_user" => preexisting_authenticated_user, "request_id" => preexisting_request_id }],
       }
 
       described_class.new.call("worker_class", job, "queue", "redis_pool") do
-        expect(job["args"].last[:request_id]).to eq(preexisting_request_id)
-        expect(job["args"].last[:authenticated_user]).to eq(preexisting_authenticated_user)
+        expect(job["args"].last["request_id"]).to eq(preexisting_request_id)
+        expect(job["args"].last["authenticated_user"]).to eq(preexisting_authenticated_user)
       end
     end
 
@@ -40,12 +40,12 @@ RSpec.describe GovukSidekiq::APIHeaders do
       GdsApi::GovukHeaders.set_header(:govuk_request_id, govuk_request_id)
 
       job = {
-        "args" => [{ authenticated_user: govuk_authenticated_user }],
+        "args" => [{ "authenticated_user" => govuk_authenticated_user }],
       }
 
       described_class.new.call("worker_class", job, "queue", "redis_pool") do
-        expect(job["args"].last[:request_id]).to eq(govuk_request_id)
-        expect(job["args"].last[:authenticated_user]).to eq(govuk_authenticated_user)
+        expect(job["args"].last["request_id"]).to eq(govuk_request_id)
+        expect(job["args"].last["authenticated_user"]).to eq(govuk_authenticated_user)
       end
     end
 
@@ -53,12 +53,12 @@ RSpec.describe GovukSidekiq::APIHeaders do
       GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, govuk_authenticated_user)
 
       job = {
-        "args" => [{ request_id: govuk_request_id }],
+        "args" => [{ "request_id" => govuk_request_id }],
       }
 
       described_class.new.call("worker_class", job, "queue", "redis_pool") do
-        expect(job["args"].last[:request_id]).to eq(govuk_request_id)
-        expect(job["args"].last[:authenticated_user]).to eq(govuk_authenticated_user)
+        expect(job["args"].last["request_id"]).to eq(govuk_request_id)
+        expect(job["args"].last["authenticated_user"]).to eq(govuk_authenticated_user)
       end
     end
 
@@ -66,13 +66,13 @@ RSpec.describe GovukSidekiq::APIHeaders do
       GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, govuk_authenticated_user)
 
       job = {
-        "args" => [{ request_id: govuk_request_id, other_request_id: preexisting_request_id }],
+        "args" => [{ "request_id" => govuk_request_id, "other_request_id" => preexisting_request_id }],
       }
 
       described_class.new.call("worker_class", job, "queue", "redis_pool") do
-        expect(job["args"].last[:request_id]).to eq(govuk_request_id)
-        expect(job["args"].last[:other_request_id]).to eq(preexisting_request_id)
-        expect(job["args"].last[:authenticated_user]).to eq(govuk_authenticated_user)
+        expect(job["args"].last["request_id"]).to eq(govuk_request_id)
+        expect(job["args"].last["other_request_id"]).to eq(preexisting_request_id)
+        expect(job["args"].last["authenticated_user"]).to eq(govuk_authenticated_user)
       end
     end
   end


### PR DESCRIPTION
This upgrades Sidekiq to version 6

Version 6 introduces some pretty significant changes to how logging is done. Not only are you no longer allowed to log to JSON files (see commits for more info) but you also can't send sidekiq logs with symbolised keys. 

When upgrading to this version both of these things will need to be taken into account. Any keys being sent as symbols will need to be swapped or you won't get logs. You will also need to make sure you're sending logs to STDERR or STDOUT because JSON files are no longer supported

Trello - https://trello.com/c/SAr31eZj/149-upgrade-sidekiq-to-v6