### PR TITLE
Test against Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.7, '3.0', 3.1]
+        ruby: [2.7, '3.0', 3.1, 3.2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Change Sidekiq dependency to "~> 5" rather than ">= 5, < 6" to ensure Sidekiq 6 pre-releases aren't installed.
+
 # 5.0.0
 
 * BREAKING: Redis is configured with REDIS_URL environment, the previous approach (REDIS_HOST and REDIS_PORT) is no longer supported.

--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gds-api-adapters", ">= 19.1.0"
   spec.add_dependency "govuk_app_config", ">= 1.1"
   spec.add_dependency "redis-namespace", "~> 1.6"
-  spec.add_dependency "sidekiq", ">= 5", "< 6"
+  spec.add_dependency "sidekiq", "~> 5"
   spec.add_dependency "sidekiq-logging-json", "~> 0.0"
   spec.add_dependency "sidekiq-statsd", ">= 2.1"
 


### PR DESCRIPTION
Ruby 3.2 was released on December 25th 2022