### PR TITLE
Remove support for Statsd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Drop support for Ruby 2.7
+* Remove support for Statsd, as this is being [deprecated from `govuk_app_config` in a later release](https://github.com/alphagov/govuk_app_config/commit/71f4f2fa3871721e5c8140bcf73d683e09d8d7b2)
 
 # 6.0.0
 * BREAKING: Upgrades the underlying version of Sidekiq to version 6. Will require changes to logging strategy;

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ What does `govuk_sidekiq` do for you?
  [Read more about request tracing][req-tracing].
 3. Makes sure that we use JSON logging, so that Sidekiq logs will end up
  properly in Kibana.
-4. Sends activity stats to Statsd, so that you can make pretty graphs of activity
- in Grafana or Graphite. See the [Rummager dashboards for an example](https://grafana.publishing.service.gov.uk/dashboard/file/rummager_queues.json).
 
 [req-tracing]: https://docs.publishing.service.gov.uk/manual/setting-up-request-tracing.html
 

--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "govuk_app_config", ">= 1.1"
   spec.add_dependency "redis-namespace", "~> 1.6"
   spec.add_dependency "sidekiq", "~> 6"
-  spec.add_dependency "sidekiq-statsd", ">= 2.1"
 
   spec.add_development_dependency "climate_control", "~> 1.2"
   spec.add_development_dependency "railties", "~> 7"

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -1,7 +1,5 @@
 require "sidekiq"
-require "sidekiq-statsd"
 require "govuk_sidekiq/api_headers"
-require "govuk_app_config/govuk_statsd"
 
 module GovukSidekiq
   module SidekiqInitializer
@@ -26,7 +24,6 @@ module GovukSidekiq
         config.redis = redis_config
 
         config.server_middleware do |chain|
-          chain.add Sidekiq::Statsd::ServerMiddleware, statsd: GovukStatsd, env: nil, prefix: "workers"
           chain.add GovukSidekiq::APIHeaders::ServerMiddleware
         end
       end


### PR DESCRIPTION
Statsd is no longer being used since replatforming to EKS, therefore we don't need to include support in this gem.

Support for Statsd will also be removed from `govuk_app_config` in a future release (see https://github.com/alphagov/govuk_app_config/commit/71f4f2fa3871721e5c8140bcf73d683e09d8d7b2), so this is a prerequisite step.