### PR TITLE
Add govuk_request_id to be part of the error and info logs in workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 7.1.0
+
+* Add govuk_request_id to Sidekiq::Context so it will be included in logging
+* Introduce a GOV.UK Logging format which has a field structure similar to GOV.UK's Rails logstasher for consistent field names
+
 # 7.0.0
 
 * BREAKING: Drop support for Ruby 2.7

--- a/lib/govuk_sidekiq/api_headers.rb
+++ b/lib/govuk_sidekiq/api_headers.rb
@@ -1,4 +1,5 @@
 require "gds_api/govuk_headers"
+require "sidekiq"
 
 module GovukSidekiq
   module APIHeaders
@@ -16,6 +17,7 @@ module GovukSidekiq
         else
           job["args"] << header_arguments
         end
+        Sidekiq::Context.add("govuk_request_id", job["args"].last["request_id"])
 
         yield
       end
@@ -45,6 +47,7 @@ module GovukSidekiq
           authenticated_user = last_arg["authenticated_user"]
           GdsApi::GovukHeaders.set_header(:govuk_request_id, request_id)
           GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, authenticated_user)
+          Sidekiq::Context.add("govuk_request_id", request_id)
         end
 
         yield

--- a/lib/govuk_sidekiq/govuk_json_formatter.rb
+++ b/lib/govuk_sidekiq/govuk_json_formatter.rb
@@ -1,0 +1,19 @@
+require "sidekiq"
+require "govuk_sidekiq/api_headers"
+
+module GovukSidekiq
+  class GovukJsonFormatter < Sidekiq::Logger::Formatters::Base
+    def call(severity, time, _, message)
+      hash = {
+        "@timestamp": time.utc.iso8601(3),
+        pid: ::Process.pid,
+        tid: tid,
+        level: severity,
+        message: message,
+        tags: %w[sidekiq],
+      }
+      ctx.each { |key, value| hash[key] = value unless hash[key] }
+      Sidekiq.dump_json(hash) << "\n"
+    end
+  end
+end

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -1,5 +1,6 @@
 require "sidekiq"
 require "govuk_sidekiq/api_headers"
+require "govuk_sidekiq/govuk_json_formatter"
 
 module GovukSidekiq
   module SidekiqInitializer
@@ -10,8 +11,6 @@ module GovukSidekiq
       )
 
       Sidekiq.configure_server do |config|
-        config.log_formatter = Sidekiq::Logger::Formatters::JSON.new if ENV["GOVUK_SIDEKIQ_JSON_LOGGING"]
-
         # $real_stdout is defined by govuk_app_config and is used to point to
         # STDOUT as that redirects $stdout to actually be $stderr.
         # When govuk_app_config does this we need to use $real_stdout to output logs to STDOUT.
@@ -20,6 +19,7 @@ module GovukSidekiq
         # rubocop:disable Style/GlobalVars
         config.logger = Sidekiq::Logger.new($real_stdout) if defined?($real_stdout)
         # rubocop:enable Style/GlobalVars
+        config.log_formatter = GovukSidekiq::GovukJsonFormatter.new if ENV["GOVUK_SIDEKIQ_JSON_LOGGING"]
 
         config.redis = redis_config
 

--- a/lib/govuk_sidekiq/version.rb
+++ b/lib/govuk_sidekiq/version.rb
@@ -1,3 +1,3 @@
 module GovukSidekiq
-  VERSION = "7.0.0".freeze
+  VERSION = "7.1.0".freeze
 end

--- a/spec/govuk_sidekiq/api_headers_spec.rb
+++ b/spec/govuk_sidekiq/api_headers_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe GovukSidekiq::APIHeaders do
       described_class.new.call("worker_class", job, "queue", "redis_pool") do
         expect(job["args"].last["request_id"]).to eq(govuk_request_id)
         expect(job["args"].last["authenticated_user"]).to eq(govuk_authenticated_user)
+        expect(Sidekiq::Context.current).to eq({ "govuk_request_id" => govuk_request_id })
       end
     end
 
@@ -33,6 +34,7 @@ RSpec.describe GovukSidekiq::APIHeaders do
       described_class.new.call("worker_class", job, "queue", "redis_pool") do
         expect(job["args"].last["request_id"]).to eq(preexisting_request_id)
         expect(job["args"].last["authenticated_user"]).to eq(preexisting_authenticated_user)
+        expect(Sidekiq::Context.current).to eq({ "govuk_request_id" => preexisting_request_id })
       end
     end
 
@@ -46,6 +48,7 @@ RSpec.describe GovukSidekiq::APIHeaders do
       described_class.new.call("worker_class", job, "queue", "redis_pool") do
         expect(job["args"].last["request_id"]).to eq(govuk_request_id)
         expect(job["args"].last["authenticated_user"]).to eq(govuk_authenticated_user)
+        expect(Sidekiq::Context.current).to eq({ "govuk_request_id" => govuk_request_id })
       end
     end
 
@@ -59,6 +62,7 @@ RSpec.describe GovukSidekiq::APIHeaders do
       described_class.new.call("worker_class", job, "queue", "redis_pool") do
         expect(job["args"].last["request_id"]).to eq(govuk_request_id)
         expect(job["args"].last["authenticated_user"]).to eq(govuk_authenticated_user)
+        expect(Sidekiq::Context.current).to eq({ "govuk_request_id" => govuk_request_id })
       end
     end
 
@@ -73,6 +77,7 @@ RSpec.describe GovukSidekiq::APIHeaders do
         expect(job["args"].last["request_id"]).to eq(govuk_request_id)
         expect(job["args"].last["other_request_id"]).to eq(preexisting_request_id)
         expect(job["args"].last["authenticated_user"]).to eq(govuk_authenticated_user)
+        expect(Sidekiq::Context.current).to eq({ "govuk_request_id" => govuk_request_id })
       end
     end
   end
@@ -93,6 +98,7 @@ RSpec.describe GovukSidekiq::APIHeaders do
         expect(message["args"]).to eq(["some arg"])
         expect(GdsApi::GovukHeaders.headers[:govuk_request_id]).to eq(govuk_request_id)
         expect(GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user]).to eq(govuk_authenticated_user)
+        expect(Sidekiq::Context.current).to eq({ "govuk_request_id" => govuk_request_id })
       end
     end
 
@@ -107,6 +113,7 @@ RSpec.describe GovukSidekiq::APIHeaders do
       original_message = message.dup
 
       expect(GdsApi::GovukHeaders).not_to receive(:set_header)
+      expect(Sidekiq::Context).not_to receive(:add)
 
       described_class.new.call("worker", message, "queue") do
         expect(message).to eq(original_message)
@@ -123,6 +130,7 @@ RSpec.describe GovukSidekiq::APIHeaders do
       original_message = message.dup
 
       expect(GdsApi::GovukHeaders).not_to receive(:set_header)
+      expect(Sidekiq::Context).not_to receive(:add)
 
       described_class.new.call("worker", message, "queue") do
         expect(message).to eq(original_message)

--- a/spec/govuk_sidekiq/govuk_json_formatter_spec.rb
+++ b/spec/govuk_sidekiq/govuk_json_formatter_spec.rb
@@ -1,0 +1,19 @@
+require "govuk_sidekiq/govuk_json_formatter"
+
+RSpec.describe GovukSidekiq::GovukJsonFormatter do
+  it "outputs a json value with govuk request id" do
+    Sidekiq::Context.add("govuk_request_id", "another-unique-request-id")
+    json_formatter = described_class.new
+    my_msg = json_formatter.call("info", Time.new(2007, 11, 1, 15, 25, 0, "+09:00"), nil, "A Meaningful message")
+    msg_hash = JSON.parse(my_msg)
+
+    expect(msg_hash).to match(hash_including(
+                                "pid" => anything,
+                                "level" => anything,
+                                "govuk_request_id" => "another-unique-request-id",
+                                "message" => "A Meaningful message",
+                                "tags" => %w[sidekiq],
+                                "@timestamp" => "2007-11-01T06:25:00.000Z",
+                              ))
+  end
+end


### PR DESCRIPTION
Current logger formatter does not contain govuk request ID which is important for traceability across logs from services. So we replace the current JSON formatter sidekiq is using to a custom JSON formatter that includes govuk request ID.

Co-authored-by: Neamah Al Selwi <neamah.alselwi@digital.cabinet-office.gov.uk>
Co-authored-by: Tuomas Nylund <tuomas.nylund@digital.cabinet-office.gov.uk>