### PR TITLE
Update govuk_sidekiq.gemspec

### DIFF
--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gds-api-adapters", ">= 19.1.0"
   spec.add_dependency "govuk_app_config", ">= 1.1"
   spec.add_dependency "redis-namespace", "~> 1.6"
-  spec.add_dependency "sidekiq", "~> 6"
+  spec.add_dependency "sidekiq", "~> < 7"
 
   spec.add_development_dependency "climate_control", "~> 1.2"
   spec.add_development_dependency "railties", "~> 7"


### PR DESCRIPTION
Bump Sidekiq version

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
