### PR TITLE
Change Sidekiq requirement to ~> 6.5, and release version 7.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix Sidekiq requirement to ~> 6.5 so that Bundler won't install v7.0.0.beta1
+
 # 7.1.2
 
 * Allow newer non-major versions of Sidekiq

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 7.1.3
 
 * Fix Sidekiq requirement to ~> 6.5 so that Bundler won't install v7.0.0.beta1
 

--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gds-api-adapters", ">= 19.1.0"
   spec.add_dependency "govuk_app_config", ">= 1.1"
   spec.add_dependency "redis-namespace", "~> 1.6"
-  spec.add_dependency "sidekiq", ">= 6.5.12", "< 7"
+  spec.add_dependency "sidekiq", "~> 6.5"
 
   spec.add_development_dependency "climate_control", "~> 1.2"
   spec.add_development_dependency "railties", "~> 7"

--- a/lib/govuk_sidekiq/version.rb
+++ b/lib/govuk_sidekiq/version.rb
@@ -1,3 +1,3 @@
 module GovukSidekiq
-  VERSION = "7.1.2".freeze
+  VERSION = "7.1.3".freeze
 end


### PR DESCRIPTION
The current version range allows Sidekiq 7.0.0.beta1 for some reason (RubyGems' versioning presumably thinks 7.0.0.beta1 < 7.0.0). This is a problem because we don't support Sidekiq 7 yet! [It's also really confusing Dependabot](https://github.com/alphagov/support/pull/1206).