### PR TITLE
Redefine sidekiq requirement to not install beta version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Redefine sidekiq requirement so Bundler won't install 7.0.0.beta1
+
 # 7.1.4
 
 * Require sidekiq > 6.5.10 and < 7

--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gds-api-adapters", ">= 19.1.0"
   spec.add_dependency "govuk_app_config", ">= 1.1"
   spec.add_dependency "redis-namespace", "~> 1.6"
-  spec.add_dependency "sidekiq", "> 6.5.10", "< 7"
+  spec.add_dependency "sidekiq", "~> 6.5", ">= 6.5.12"
 
   spec.add_development_dependency "climate_control", "~> 1.2"
   spec.add_development_dependency "railties", "~> 7"


### PR DESCRIPTION
Currently, bundler will install version `7.0.0.beta1` of sidekiq as it considers this to be less than `7`. We do not want this to happen.

In https://github.com/alphagov/govuk_sidekiq/pull/84, we changed the requirement from `">= 6.5.12", "< 7"` to `"~> 6.5"`. This has a side effect of some of our applications ending up on an earlier version of sidekiq than `6.5.12` (there was a security fix in `6.5.10`).

Therefore in https://github.com/alphagov/govuk_sidekiq/pull/85 we changed the requirement to be `"> 6.5.10", "< 7"`, however this once again resulted in bundler installing `7.0.0.beta`.

Updating the requirements again to be even more explicit, so we always install a version newer than `6.5.12` but never a version that isn't `6.5.x`.

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
