### PR TITLE
Skip Snyk SCA scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ jobs:
   snyk-security:
     name: SNYK security analysis
     uses: alphagov/govuk-infrastructure/.github/workflows/snyk-security.yml@main
+    with:
+      skip_sca: true
     secrets: inherit
   
   codeql-sast:


### PR DESCRIPTION
[Trello card](https://trello.com/c/UNfbKmbK/3460-skip-snyk-sca-scans-for-all-gem-library-repos)

Snyk’s SCA scans currently fail on this repo, because Snyk is looking for
Gemfile.lock, but gem repos don’t have/need one.

SCA in general doesn’t really make sense for gems (or any type of
library), because they don’t lock a specific version of their
dependencies.