### PR TITLE
Update Redis reconnect attempt strategy to retry more times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Drop support for Ruby 3.0. The minimum required Ruby version is now 3.1.4.
 * Add support for Ruby 3.3.
+* Update Redis reconnect attempt strategy to retry more times.
 
 # 7.1.5
 

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -7,7 +7,12 @@ module GovukSidekiq
     def self.setup_sidekiq(govuk_app_name, redis_config = {})
       redis_config = redis_config.merge(
         namespace: govuk_app_name,
-        reconnect_attempts: 1,
+        reconnect_attempts: [
+          0,
+          15,
+          30,
+          60,
+        ],
       )
 
       Sidekiq.configure_server do |config|


### PR DESCRIPTION
We currently retry once immediately to connect to Redis. This is being increased to retry multiple times, up to one minute, ahead of migrating away from the shared Redis instance.

See the [redis-rb documentation](https://github.com/redis/redis-rb?tab=readme-ov-file#reconnections) to see the permitted values for this setting.

[Trello card](https://trello.com/c/VBVIEUim)