### PR TITLE
Release version 8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Unreleased
+# 8.0.0
 
-* Drop support for Ruby 3.0. The minimum required Ruby version is now 3.1.4.
+* BREAKING: Drop support for Ruby 3.0. The minimum required Ruby version is now 3.1.4.
 * Add support for Ruby 3.3.
 * Update Redis reconnect attempt strategy to retry more times.
 

--- a/lib/govuk_sidekiq/version.rb
+++ b/lib/govuk_sidekiq/version.rb
@@ -1,3 +1,3 @@
 module GovukSidekiq
-  VERSION = "7.1.5".freeze
+  VERSION = "8.0.0".freeze
 end


### PR DESCRIPTION
I've made this into a major change, as the removal of support for Ruby 3.0 feels like it's a breaking change.

[Trello card](https://trello.com/c/VBVIEUim)