### PR TITLE
Fix `reconnect_attempts` not working with Redis 4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix support for `reconnect_attempts` not working with Redis 4.8 (which is required due to the sidekiq version specified)
+
 # 8.0.0
 
 * BREAKING: Drop support for Ruby 3.0. The minimum required Ruby version is now 3.1.4.

--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "gds-api-adapters", ">= 19.1.0"
   spec.add_dependency "govuk_app_config", ">= 1.1"
+  spec.add_dependency "redis", "< 5"
   spec.add_dependency "redis-namespace", "~> 1.6"
   spec.add_dependency "sidekiq", "~> 6.5", ">= 6.5.12"
 

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -7,12 +7,9 @@ module GovukSidekiq
     def self.setup_sidekiq(govuk_app_name, redis_config = {})
       redis_config = redis_config.merge(
         namespace: govuk_app_name,
-        reconnect_attempts: [
-          0,
-          15,
-          30,
-          60,
-        ],
+        reconnect_attempts: 4,
+        reconnect_delay: 15,
+        reconnect_delay_max: 60,
       )
 
       Sidekiq.configure_server do |config|


### PR DESCRIPTION
Our apps are currently using Redis 4.8 due to a constraint from the version of Sidekiq we are using.

However in a previous commit, we used Redis 5 syntax to specify a new value for `reconnect_attempts`. This is not compatible with Redis 4.8.

Therefore updating the syntax to match that expected for [Redis 4.8](https://github.com/redis/redis-rb/tree/v4.8.1?tab=readme-ov-file#reconnections) and explicitly stating the version of Redis we expect (since Redis 5 doesn't support the legacy syntax).

[Trello card](https://trello.com/c/VBVIEUim)