### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Continuous integration
+name: CI
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
This workflow should be called CI like all others.

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
