### PR TITLE
Upgrade to Sidekiq 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Switch from using `redis` gem to `redis-client`
 * BREAKING: Remove `redis-namespace` dependency and support for Redis namespaces
+  * Run the `redis_namespace:remove_namespace` rake task immediately after upgrading to to this version, to retain existing queued jobs.
 * BREAKING: Upgrade Sidekiq to version 7.0, follow these steps to upgrade:
   1. `Sidekiq::Worker` has been deprecated in Sidekiq 7. Replace all instances of `Sidekiq::Worker` with `Sidekiq::Job`, then rename/move your workers to be `app/sidekiq/MyJob.rb` instead of `app/workers/MyWorker.rb`.
   1. Remove the requirement for Sidekiq strict arguments from `config/initializers/sidekiq.rb`. This was added to include Sidekiq 7 strict arguments behaviour in Sidekiq 6, but is no longer needed to be explictly required, since this is now the default behaviour.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 9.0.0
 
 * Switch from using `redis` gem to `redis-client`
 * BREAKING: Remove `redis-namespace` dependency and support for Redis namespaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Switch from using `redis` gem to `redis-client`
 * BREAKING: Remove `redis-namespace` dependency and support for Redis namespaces
+* BREAKING: Upgrade Sidekiq to version 7.0
 
 # 8.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Switch from using `redis` gem to `redis-client`
+
 # 8.0.1
 
 * Fix support for `reconnect_attempts` not working with Redis 4.8 (which is required due to the sidekiq version specified)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 * Switch from using `redis` gem to `redis-client`
 * BREAKING: Remove `redis-namespace` dependency and support for Redis namespaces
-* BREAKING: Upgrade Sidekiq to version 7.0
+* BREAKING: Upgrade Sidekiq to version 7.0, follow these steps to upgrade:
+  1. `Sidekiq::Worker` has been deprecated in Sidekiq 7. Replace all instances of `Sidekiq::Worker` with `Sidekiq::Job`, then rename/move your workers to be `app/sidekiq/MyJob.rb` instead of `app/workers/MyWorker.rb`.
+  1. Remove the requirement for Sidekiq strict arguments from `config/initializers/sidekiq.rb`. This was added to include Sidekiq 7 strict arguments behaviour in Sidekiq 6, but is no longer needed to be explictly required, since this is now the default behaviour.
+  1. If using `sidekiq-unique-jobs`, pin to < 8.0.8 until [a known issue](https://github.com/mhenrixon/sidekiq-unique-jobs/issues/846) is resolved.
+  1. Make any changes required based on the information in the [Sidekiq 7 API migration guide](https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-API-Migration.md).
 
 # 8.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Switch from using `redis` gem to `redis-client`
+* BREAKING: Remove `redis-namespace` dependency and support for Redis namespaces
 
 # 8.0.1
 

--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gds-api-adapters", ">= 19.1.0"
   spec.add_dependency "govuk_app_config", ">= 1.1"
   spec.add_dependency "redis-client", ">= 0.22.2"
-  spec.add_dependency "sidekiq", "~> 6.5", ">= 6.5.12"
+  spec.add_dependency "sidekiq", "~> 7.0", "< 8"
 
   spec.add_development_dependency "climate_control", "~> 1.2"
   spec.add_development_dependency "railties", "~> 7"

--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "gds-api-adapters", ">= 19.1.0"
   spec.add_dependency "govuk_app_config", ">= 1.1"
   spec.add_dependency "redis-client", ">= 0.22.2"
-  spec.add_dependency "redis-namespace", "~> 1.6"
   spec.add_dependency "sidekiq", "~> 6.5", ">= 6.5.12"
 
   spec.add_development_dependency "climate_control", "~> 1.2"

--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "gds-api-adapters", ">= 19.1.0"
   spec.add_dependency "govuk_app_config", ">= 1.1"
-  spec.add_dependency "redis", "< 5"
+  spec.add_dependency "redis-client", ">= 0.22.2"
   spec.add_dependency "redis-namespace", "~> 1.6"
   spec.add_dependency "sidekiq", "~> 6.5", ">= 6.5.12"
 

--- a/lib/govuk_sidekiq/railtie.rb
+++ b/lib/govuk_sidekiq/railtie.rb
@@ -2,9 +2,8 @@ require "govuk_sidekiq/sidekiq_initializer"
 
 module GovukSidekiq
   class Railtie < Rails::Railtie
-    initializer "govuk_sidekiq.initialize_sidekiq" do |app|
+    initializer "govuk_sidekiq.initialize_sidekiq" do
       SidekiqInitializer.setup_sidekiq(
-        ENV.fetch("GOVUK_APP_NAME", app.root.basename.to_s),
         { url: ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379") },
       )
     end

--- a/lib/govuk_sidekiq/railtie.rb
+++ b/lib/govuk_sidekiq/railtie.rb
@@ -7,5 +7,10 @@ module GovukSidekiq
         { url: ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379") },
       )
     end
+
+    rake_tasks do
+      path = File.expand_path(__dir__)
+      Dir.glob("#{path}/tasks/**/*.rake").each { |f| load f }
+    end
   end
 end

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -6,7 +6,6 @@ module GovukSidekiq
   module SidekiqInitializer
     def self.setup_sidekiq(govuk_app_name, redis_config = {})
       redis_config = redis_config.merge(
-        namespace: govuk_app_name,
         reconnect_attempts: 4,
         reconnect_delay: 15,
         reconnect_delay_max: 60,

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -4,12 +4,8 @@ require "govuk_sidekiq/govuk_json_formatter"
 
 module GovukSidekiq
   module SidekiqInitializer
-    def self.setup_sidekiq(govuk_app_name, redis_config = {})
-      redis_config = redis_config.merge(
-        reconnect_attempts: 4,
-        reconnect_delay: 15,
-        reconnect_delay_max: 60,
-      )
+    def self.setup_sidekiq(redis_config = {})
+      redis_config = redis_config.merge(reconnect_attempts: [15, 30, 45, 60])
 
       Sidekiq.configure_server do |config|
         # $real_stdout is defined by govuk_app_config and is used to point to
@@ -20,7 +16,7 @@ module GovukSidekiq
         # rubocop:disable Style/GlobalVars
         config.logger = Sidekiq::Logger.new($real_stdout) if defined?($real_stdout)
         # rubocop:enable Style/GlobalVars
-        config.log_formatter = GovukSidekiq::GovukJsonFormatter.new if ENV["GOVUK_SIDEKIQ_JSON_LOGGING"]
+        config.logger.formatter = GovukSidekiq::GovukJsonFormatter.new if ENV["GOVUK_SIDEKIQ_JSON_LOGGING"]
 
         config.redis = redis_config
 

--- a/lib/govuk_sidekiq/tasks/redis_namespace.rake
+++ b/lib/govuk_sidekiq/tasks/redis_namespace.rake
@@ -1,0 +1,15 @@
+namespace :redis_namespace do
+  desc "Remove application specific namespacing for all Redis keys"
+  task :remove_namespace, :environment do
+    namespace = ENV["GOVUK_APP_NAME"]
+
+    redis = RedisClient.new(url: ENV["REDIS_URL"])
+
+    namespaced_keys = redis.call("KEYS", "#{namespace}:*")
+
+    namespaced_keys.each do |key|
+      new_key = key.gsub(/^#{namespace}:/, "")
+      redis.call("RENAME", key, new_key)
+    end
+  end
+end

--- a/lib/govuk_sidekiq/version.rb
+++ b/lib/govuk_sidekiq/version.rb
@@ -1,3 +1,3 @@
 module GovukSidekiq
-  VERSION = "8.0.1".freeze
+  VERSION = "9.0.0".freeze
 end

--- a/spec/govuk_sidekiq/railtie_spec.rb
+++ b/spec/govuk_sidekiq/railtie_spec.rb
@@ -4,32 +4,21 @@ require "govuk_sidekiq/railtie"
 
 RSpec.describe GovukSidekiq::Railtie do
   let(:app) { instance_double(Rails::Application, root: Pathname.new("rails/app")) }
-  let(:default_app_name) { "app" }
   let(:default_redis_configuration) { { url: "redis://127.0.0.1:6379" } }
 
   it "initializes SidekiqInitializer with default options" do
     expect(GovukSidekiq::SidekiqInitializer)
       .to receive(:setup_sidekiq)
-      .with(default_app_name, default_redis_configuration)
+      .with(default_redis_configuration)
 
     described_class.initializers.first.run(app)
-  end
-
-  it "can set app name via on an env var" do
-    ClimateControl.modify GOVUK_APP_NAME: "my-app" do
-      expect(GovukSidekiq::SidekiqInitializer)
-        .to receive(:setup_sidekiq)
-        .with("my-app", default_redis_configuration)
-
-      described_class.initializers.first.run(app)
-    end
   end
 
   it "can set Redis URL via on an env var" do
     ClimateControl.modify REDIS_URL: "redis://redis" do
       expect(GovukSidekiq::SidekiqInitializer)
         .to receive(:setup_sidekiq)
-        .with(default_app_name, { url: "redis://redis" })
+        .with({ url: "redis://redis" })
 
       described_class.initializers.first.run(app)
     end

--- a/spec/govuk_sidekiq/railtie_spec.rb
+++ b/spec/govuk_sidekiq/railtie_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe GovukSidekiq::Railtie do
   let(:app) { instance_double(Rails::Application, root: Pathname.new("rails/app")) }
   let(:default_redis_configuration) { { url: "redis://127.0.0.1:6379" } }
 
+  before { ENV["REDIS_URL"] = "redis://127.0.0.1:6379" }
+
   it "initializes SidekiqInitializer with default options" do
     expect(GovukSidekiq::SidekiqInitializer)
       .to receive(:setup_sidekiq)

--- a/spec/govuk_sidekiq/sidekiq_initializer_spec.rb
+++ b/spec/govuk_sidekiq/sidekiq_initializer_spec.rb
@@ -3,7 +3,7 @@ require "govuk_sidekiq/sidekiq_initializer"
 RSpec.describe GovukSidekiq::SidekiqInitializer do
   it "doesn't error when called" do
     expect {
-      described_class.setup_sidekiq("govuk_app_name", { url: "redis://redis" })
+      described_class.setup_sidekiq({ url: "redis://redis" })
     }.not_to raise_error
   end
 end

--- a/spec/integration/check_a_sidekiq_worker_can_perform_spec.rb
+++ b/spec/integration/check_a_sidekiq_worker_can_perform_spec.rb
@@ -3,7 +3,7 @@ require "govuk_sidekiq/sidekiq_initializer"
 
 RSpec.describe "Check a Sidekiq Worker can perform" do
   before do
-    GovukSidekiq::SidekiqInitializer.setup_sidekiq("test_app", {})
+    GovukSidekiq::SidekiqInitializer.setup_sidekiq({})
   end
 
   it "can run the test worker" do

--- a/spec/integration/check_a_sidekiq_worker_can_perform_spec.rb
+++ b/spec/integration/check_a_sidekiq_worker_can_perform_spec.rb
@@ -3,6 +3,7 @@ require "govuk_sidekiq/sidekiq_initializer"
 
 RSpec.describe "Check a Sidekiq Worker can perform" do
   before do
+    ENV["REDIS_URL"] = "redis://redis"
     GovukSidekiq::SidekiqInitializer.setup_sidekiq({})
   end
 


### PR DESCRIPTION
This upgrades to Sidekiq 7 and releases version 9.0.0 of the gem.

Upgrading to Sidekiq 7 includes a number of breaking changes, which require action to be taken in applications.  These steps are detailed in the `CHANGELOG`.

[Trello card](https://trello.com/c/knx2tuL4)