### PR TITLE
Add autorelease workflow

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,0 +1,10 @@
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '30 10 * * 1-5' # 10:30am UTC, Mon-Fri.
+
+jobs:
+  autorelease:
+    uses: alphagov/govuk-infrastructure/.github/workflows/autorelease-rubygem.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}


### PR DESCRIPTION
This will allow the gem to release patch versions when dependencies are updated. This will reduce some toil for the team.

[Trello](https://trello.com/c/y82nGFUL/1377-implement-gem-autorelease-workflow)

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
