### PR TITLE
Allow setting Redis SSL verify_mode via env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Allow setting of Redis SSL `verify_mode` to none via environment variable
+
 # 9.0.0
 
 * Switch from using `redis` gem to `redis-client`

--- a/lib/govuk_sidekiq/railtie.rb
+++ b/lib/govuk_sidekiq/railtie.rb
@@ -3,9 +3,13 @@ require "govuk_sidekiq/sidekiq_initializer"
 module GovukSidekiq
   class Railtie < Rails::Railtie
     initializer "govuk_sidekiq.initialize_sidekiq" do
-      SidekiqInitializer.setup_sidekiq(
-        { url: ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379") },
-      )
+      redis_options = { url: ENV.fetch("REDIS_URL", "redis://127.0.0.1:6379") }
+
+      if ENV["REDIS_SSL_VERIFY_NONE"] == "true"
+        redis_options[:ssl_params] = { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+      end
+
+      SidekiqInitializer.setup_sidekiq(redis_options)
     end
 
     rake_tasks do

--- a/spec/govuk_sidekiq/railtie_spec.rb
+++ b/spec/govuk_sidekiq/railtie_spec.rb
@@ -25,4 +25,14 @@ RSpec.describe GovukSidekiq::Railtie do
       described_class.initializers.first.run(app)
     end
   end
+
+  it "can set Redis SSL verify_mode to none via an env var" do
+    ClimateControl.modify REDIS_SSL_VERIFY_NONE: "true" do
+      expect(GovukSidekiq::SidekiqInitializer)
+        .to receive(:setup_sidekiq)
+        .with(default_redis_configuration.merge({ ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }))
+
+      described_class.initializers.first.run(app)
+    end
+  end
 end


### PR DESCRIPTION
When using Redis 6 and above, Heroku Redis requires TLS [1] but uses
self-signed certificates. As a result, Sidekiq cannot connect to Redis
on Heroku.

The official Heroku docs specify configuring `verify_mode` to `none`
is the right move here. Heroku terminates SSL at the router and internal
requests are all HTTP anyway.

We obviously don't want this as the default setting, so we can turn off
verification via an env var that we'll just set in Heroku environments.

See also https://stackoverflow.com/q/65834575

[1] https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance