### PR TITLE
Reduce the time window for Sidekiq retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-
+* Allow clients to pass in own value for Redis reconnect_attempts
 * Reduce Redis reconnection timeout from 15-60s to 0.05-5s
 
 ## 9.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+
+* Reduce Redis reconnection timeout from 15-60s to 0.05-5s
+
 ## 9.0.3
 
 * Update dependencies

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -5,7 +5,7 @@ require "govuk_sidekiq/govuk_json_formatter"
 module GovukSidekiq
   module SidekiqInitializer
     def self.setup_sidekiq(redis_config = {})
-      redis_config = redis_config.merge(reconnect_attempts: [0.05, 0.25, 1, 5])
+      redis_config[:reconnect_attempts] ||= [0.05, 0.25, 1, 5]
 
       Sidekiq.configure_server do |config|
         # $real_stdout is defined by govuk_app_config and is used to point to

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -5,7 +5,7 @@ require "govuk_sidekiq/govuk_json_formatter"
 module GovukSidekiq
   module SidekiqInitializer
     def self.setup_sidekiq(redis_config = {})
-      redis_config = redis_config.merge(reconnect_attempts: [15, 30, 45, 60])
+      redis_config = redis_config.merge(reconnect_attempts: [0.05, 0.25, 1, 5])
 
       Sidekiq.configure_server do |config|
         # $real_stdout is defined by govuk_app_config and is used to point to


### PR DESCRIPTION
Trello: https://trello.com/c/y9xze1am/2275-investigate-the-intermittent-15s-question-loading-on-heroku

The previous code meant that if there was a Sidekiq connection error
there would be a `sleep(15)` called before any attempt to reconnect to
Redis. For a client application serving a web request and adding to the
Sidekiq this 15 seconds is a very long time to wait.

This is substantially longer than the gem default values which are a
0.25s wait twice [1]

The motivation for making this change was finding that in a Heroku
environment (which we are currently using for demoing an app) it is
frequent that we receive an intermittment 15 second wait to serve a
request. The Redis connection must be less reliable on the cheaper
hardware.

[1]: https://github.com/redis-rb/redis-client/blob/8dfe1f65208482bb30150dd0009254ac77fe4776/lib/redis_client/sentinel_config.rb#L7-L8