### PR TITLE
Bump to version 9.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 9.0.4
+
 * Allow clients to pass in own value for Redis reconnect_attempts
 * Reduce Redis reconnection timeout from 15-60s to 0.05-5s
 

--- a/lib/govuk_sidekiq/version.rb
+++ b/lib/govuk_sidekiq/version.rb
@@ -1,3 +1,3 @@
 module GovukSidekiq
-  VERSION = "9.0.3".freeze
+  VERSION = "9.0.4".freeze
 end


### PR DESCRIPTION
Includes the changes from https://github.com/alphagov/govuk_sidekiq/pull/129

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
