### PR TITLE
Less noisy reconnection backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 9.0.6
 
 * Reinstate a couple of the old longer Redis reconnection retries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Reinstate a couple of the old longer Redis reconnection retries
+
 ## 9.0.5
 
 * Remove obsolete Redis namespaces Rake task

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -5,7 +5,7 @@ require "govuk_sidekiq/govuk_json_formatter"
 module GovukSidekiq
   module SidekiqInitializer
     def self.setup_sidekiq(redis_config = {})
-      redis_config[:reconnect_attempts] ||= [0.05, 0.25, 1, 5]
+      redis_config[:reconnect_attempts] ||= [0.05, 0.25, 1, 5, 15, 30]
 
       Sidekiq.configure_server do |config|
         # $real_stdout is defined by govuk_app_config and is used to point to

--- a/lib/govuk_sidekiq/version.rb
+++ b/lib/govuk_sidekiq/version.rb
@@ -1,3 +1,3 @@
 module GovukSidekiq
-  VERSION = "9.0.5".freeze
+  VERSION = "9.0.6".freeze
 end


### PR DESCRIPTION
Add a couple of longer Redis reconnection retries

Until recently our retries were set to [15, 30, 45, 60] (seconds). The
change to the current snappier settings has exposed how surprisingly
long it can take for new Redis instances to be available after they've
been killed. And that's resulted in a lot of noise in Sentry when Redis
instances are restarted across multiple apps and those apps can't
reconnect within 5 seconds.

We don't think that this is a great long-term fix for that, but it
should reduce the noise in Sentry while we look into our Redis setup.

https://trello.com/c/8rP2ZGUg/1566-look-into-redisclientcannotconnecterror-exceptions