### PR TITLE
[PP-7257] Add Ruby 3.4 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.2, 3.3]
+        ruby: [3.2, 3.3, 3.4]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Updates to add Ruby 3.4 into the test matrix, which was released in December 2024.