### PR TITLE
Add support for Rails apps to run Sidekiq Web behind an authentication layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 10.1.0
+
+* Add support for Rails apps to run Sidekiq Web behind an authentication layer ([PR](https://github.com/alphagov/govuk_sidekiq/pull/170))
+
 ## 10.0.0
 
 * BREAKING: Drop support for Ruby 3.1 [PR](https://github.com/alphagov/govuk_sidekiq/pull/139)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ correctly, replace `require 'sidekiq/testing'` with:
 require 'govuk_sidekiq/testing'
 ```
 
+## Sidekiq Web UI
+
+To make the Sidekiq Web UI accessible at `/sidekiq` in a Rails app:
+
+- the app must be using Warden via [gds-sso](https://github.com/alphagov/gds-sso)
+- the app must have a `Sidekiq Admin` permission in Signon
+- the logged-in user must have the `Sidekiq Admin` permission for the app
+- the following code must be added to your application's `config/routes.rb` file:
+
+```ruby
+mount GovukSidekiq::GdsSsoMiddleware, at: "/sidekiq"
+```
+
 ## Licence
 
 [MIT License](LICENCE)

--- a/govuk_sidekiq.gemspec
+++ b/govuk_sidekiq.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sidekiq", "~> 7.0", "< 8"
 
   spec.add_development_dependency "climate_control", "~> 1.2"
+  spec.add_development_dependency "gds-sso", "~> 22.1"
   spec.add_development_dependency "railties", "~> 8"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.4"

--- a/lib/govuk_sidekiq/gds_sso_middleware.rb
+++ b/lib/govuk_sidekiq/gds_sso_middleware.rb
@@ -1,0 +1,34 @@
+require "sidekiq/web"
+
+module GovukSidekiq
+  class GdsSsoMiddleware
+    SIDEKIQ_SIGNON_PERMISSION = "Sidekiq Admin".freeze
+
+    def self.call(...) = new(...).call
+
+    def initialize(env)
+      @env = env
+      @warden = env.fetch("warden")
+    end
+
+    def call
+      status, headers, body = authenticated_sidekiq_request
+
+      [status, headers, body]
+    end
+
+  private
+
+    attr_reader :env, :warden
+
+    def authenticated_sidekiq_request
+      warden.authenticate! if !warden.authenticated? || warden.user.remotely_signed_out?
+
+      if warden.user.has_permission?(SIDEKIQ_SIGNON_PERMISSION)
+        Sidekiq::Web.call(env)
+      else
+        [403, {}, ["Forbidden - access requires the \"#{SIDEKIQ_SIGNON_PERMISSION}\" permission"]]
+      end
+    end
+  end
+end

--- a/lib/govuk_sidekiq/version.rb
+++ b/lib/govuk_sidekiq/version.rb
@@ -1,3 +1,3 @@
 module GovukSidekiq
-  VERSION = "10.0.0".freeze
+  VERSION = "10.1.0".freeze
 end

--- a/spec/govuk_sidekiq/gds_sso_middleware_spec.rb
+++ b/spec/govuk_sidekiq/gds_sso_middleware_spec.rb
@@ -1,0 +1,65 @@
+require "gds-sso"
+require "govuk_sidekiq/gds_sso_middleware"
+
+class TestUser
+  include GDS::SSO::User
+  def initialize
+    @permissions = []
+    @remotely_signed_out = false
+  end
+
+  attr_accessor :permissions
+
+  def has_permission?(permission)
+    permissions.include?(permission)
+  end
+
+  def remotely_signed_out?
+    @remotely_signed_out
+  end
+end
+
+RSpec.describe GovukSidekiq::GdsSsoMiddleware do
+  let(:user) { TestUser.new }
+  let(:warden) { instance_double(Warden::Proxy, user: user, authenticated?: true) }
+
+  before do
+    allow(warden).to receive(:authenticate!)
+  end
+
+  it "proxies a request to sidekiq web for an authenticated user with a 'Sidekiq Admin' permission" do
+    user.permissions = [GovukSidekiq::GdsSsoMiddleware::SIDEKIQ_SIGNON_PERMISSION]
+    env = { "warden" => warden }
+
+    allow(Sidekiq::Web).to receive(:call).and_return([200, {}, %w[body]])
+
+    described_class.call(env)
+
+    expect(Sidekiq::Web).to have_received(:call).with(env)
+  end
+
+  it "returns a 403 forbidden response for an authenticated user without 'Sidekiq Admin' permission" do
+    user.permissions = []
+
+    status, _headers, body = described_class.call({ "warden" => warden })
+
+    expect(status).to eq(403)
+    expect(body).to eq(["Forbidden - access requires the \"#{described_class::SIDEKIQ_SIGNON_PERMISSION}\" permission"])
+  end
+
+  it "attempts to authenticate when a user is not authenticated" do
+    allow(warden).to receive(:authenticated?).and_return(false)
+
+    described_class.call({ "warden" => warden })
+
+    expect(warden).to have_received(:authenticate!)
+  end
+
+  it "attempts to authenticate when a user is remotely signed out" do
+    allow(user).to receive(:remotely_signed_out?).and_return(true)
+
+    described_class.call({ "warden" => warden })
+
+    expect(warden).to have_received(:authenticate!)
+  end
+end


### PR DESCRIPTION
This is [cribbed from Whitehall](https://github.com/alphagov/whitehall/blob/main/lib/sidekiq_gds_sso_middleware.rb) and will allow applications with Warden authentication to mount Sidekiq Web behind an authentication layer.
