### PR TITLE
[PP-7623] Use JSON for client logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 11.0.0
+
+* BREAKING: Use JSON for client logs (logs produced when pushing jobs to the
+  queue)
+
+  This is more of a fix to restore JSON logging globally which was likely
+  unintentionally limited to server logs (logs produced when processing jobs) in
+  govuk_sidekiq 6.0.0 when upgrading to Sidekiq 6, but treating it as a breaking
+  change since the current behaviour has been in place for a few years and major
+  versions.
+
 ## 10.1.0
 
 * Add support for Rails apps to run Sidekiq Web behind an authentication layer ([PR](https://github.com/alphagov/govuk_sidekiq/pull/170))

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -28,6 +28,8 @@ module GovukSidekiq
       Sidekiq.configure_client do |config|
         config.redis = redis_config
 
+        config.logger.formatter = GovukSidekiq::GovukJsonFormatter.new if ENV["GOVUK_SIDEKIQ_JSON_LOGGING"]
+
         config.client_middleware do |chain|
           chain.add GovukSidekiq::APIHeaders::ClientMiddleware
         end

--- a/lib/govuk_sidekiq/version.rb
+++ b/lib/govuk_sidekiq/version.rb
@@ -1,3 +1,3 @@
 module GovukSidekiq
-  VERSION = "10.1.0".freeze
+  VERSION = "11.0.0".freeze
 end


### PR DESCRIPTION
In Logit, when attempting to put jobs on the queue via SidekiqUniqueJobs logs we have a field like this:

```
message    2026-03-06T14:00:48.812Z pid=23 tid=c5j uniquejobs=client until_executing=uniquejobs:3f5dea0be098e73059f466d1452f3ca2 INFO: {message: "Locked", args: [{"content_id" => "8d56bb52-2f79-4b6d-9fc6-6d7dcc4f7586", "locale" => "en", "update_dependencies" => false, "orphaned_content_ids" => [], "source_command" => "put_content", "source_fields" => []}, {"authenticated_user" => "8dc80a84-f674-449b-b243-8ab710e4f1dc", "request_id" => "21-1772707418.877-10.13.20.250-2497"}], jid: "d00ba590de10a648edec6ad3", lock_args: ["8d56bb52-2f79-4b6d-9fc6-6d7dcc4f7586", "en", false, [], "DownstreamDraftJob"], queue: "downstream_high", worker: "DownstreamDraftJob"}
```

```
message    2026-03-05T16:48:55.114Z pid=23 tid=cav uniquejobs=client until_executing=uniquejobs:54be31f76aeccfb48aa5602f21144746 WARN: {message: "Lock failed to be acquired", args: [{"content_id" => "07edcd53-c7cd-464b-87be-09ee0e7b2d53", "locale" => "en", "update_dependencies" => false, "source_command" => "publish", "source_fields" => []}, {"authenticated_user" => "8dc80a84-f674-449b-b243-8ab710e4f1dc", "request_id" => "21-1772729267.091-10.13.21.81-116246"}], jid: "bf421cea281c3b201da6df81", lock_args: ["07edcd53-c7cd-464b-87be-09ee0e7b2d53", "en", false, [], "DownstreamDraftJob"], queue: "downstream_low", worker: "DownstreamDraftJob"}
```

The log message includes structured data but it's in the middle of a long pretty-printed string

Conversely, when processing jobs from the queue, the field looks like this:

```
message    {"@timestamp":"2026-03-06T14:09:56.383Z","pid":1,"tid":"97p5","level":"INFO","message":"start","tags":["sidekiq"],"class":"DownstreamDraftJob","jid":"7a21d4034f3bd994078d9537"}, start
```

This is formatted as JSON (although there is the trailing "start" or "done") and Logit exposes each field from the JSON as an individual field in the UI (e.g. `logjson.class` and `logjson_message` for "start"/"done") which makes it easier to filter and visually parse

My assumption is that this is automatic for JSON-formatted logs either via Logit or via our config: https://github.com/alphagov/govuk-infrastructure/tree/main/docs/logit/logit

---

Before Sidekiq 6, the log formatter was set outside of the blocks for configuring the server and the client and so would presumably have applied globally. When upgrading to Sidekiq 6 we moved this into the server config block per the example from the change notes and the current logging wiki page

https://github.com/alphagov/govuk_sidekiq/commit/3b29a8e1b79de450a2c9f186fae478a40b75ec09
https://github.com/sidekiq/sidekiq/blob/main/Changes.md#60
https://github.com/sidekiq/sidekiq/wiki/Logging#output-format

However, as the middleware docs explain, the server middleware is run around job execution and the client middleware is run when pushing jobs to Redis. As such, when SidekiqUniqueJobs pushes jobs to the queue it's using the client middleware rather than the server middleware. We therefore need to apply the same JSON logging setting in the client middleware to get these logs to output as JSON

https://github.com/sidekiq/sidekiq/blob/978e2bdf59ea09f796beb8c1f4763e985117e286/docs/middleware.md

Per older commit messages and GitHub discussion, the conditional here is in place so that locally we can get the pretty-printed logs but in production environments we format them as JSON for consumption by Logit etc (the environment variable is set by default via Helm Charts)

https://github.com/alphagov/govuk_sidekiq/commit/992e17f56f886208e7d57d36ab992ba883235513
https://github.com/alphagov/govuk_sidekiq/pull/63#discussion_r1035801876
https://github.com/alphagov/govuk-helm-charts/blob/5c2987d520d33b2daab98f086ddb51b2aec7e088/charts/app-config/templates/env-configmap.yaml#L30