### PR TITLE
[PP-7623] Revert log change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 11.0.1
+
+* Temporarily revert to pretty printing client logs until we're prepared to
+  consume the JSON logs
+
 ## 11.0.0
 
 * BREAKING: Use JSON for client logs (logs produced when pushing jobs to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 11.0.0
 
 * BREAKING: Use JSON for client logs (logs produced when pushing jobs to the
-  queue)
+  queue; [PR](https://github.com/alphagov/govuk_sidekiq/pull/171))
 
   This is more of a fix to restore JSON logging globally which was likely
   unintentionally limited to server logs (logs produced when processing jobs) in

--- a/lib/govuk_sidekiq/sidekiq_initializer.rb
+++ b/lib/govuk_sidekiq/sidekiq_initializer.rb
@@ -28,8 +28,6 @@ module GovukSidekiq
       Sidekiq.configure_client do |config|
         config.redis = redis_config
 
-        config.logger.formatter = GovukSidekiq::GovukJsonFormatter.new if ENV["GOVUK_SIDEKIQ_JSON_LOGGING"]
-
         config.client_middleware do |chain|
           chain.add GovukSidekiq::APIHeaders::ClientMiddleware
         end

--- a/lib/govuk_sidekiq/version.rb
+++ b/lib/govuk_sidekiq/version.rb
@@ -1,3 +1,3 @@
 module GovukSidekiq
-  VERSION = "11.0.0".freeze
+  VERSION = "11.0.1".freeze
 end


### PR DESCRIPTION
While initially this appeared to be working and Logit was adding logjson fields, after a while the logs disappeared and we later found that they were ending up in the dead letter queue (dlq)

Reverting for now while we work out how to consume the logs properly