### PR TITLE
[PP-7685] Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,29 @@ updates:
   - package-ecosystem: bundler
     directory: /
     schedule:
-      interval: daily
-  - package-ecosystem: "github-actions"
+      interval: weekly
+      day: tuesday
+      time: "07:00"
+    allow:
+      - dependency-type: direct
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 25
+    groups:
+      test:
+        patterns:
+        - "climate_control"
+        - "ostruct"
+        - "rspec"
+        - "simplecov"
+        - "webmock"
+
+  - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
+      time: "07:00"
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 25


### PR DESCRIPTION
This PR refines Dependabot configuration to reduce noise and improve update safety. It introduces cooldown periods to avoid unstable releases, groups related Bundler updates and switches to a weekly Tuesday 7:00 UTC schedule.

It also increases the open PR limit to 25 to support batching, and restricts updates to direct dependencies only for more relevant, manageable changes.

Security updates remain unaffected and continue to be raised immediately.