### PR TITLE
Fix `CHANGELOG` entry for version 11.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,17 @@
   This release introduces a new [testing API](https://sidekiq.org/wiki/Testing#new-api), which requires making a one-line change wherever `require sidekiq/testing` is currently used.
   The old testing API will be deprecated in Sidekiq 9.0.
 
-## 11.1.0
+## 11.1.2
 
 * Drop support for Ruby 3.2
+
+## 11.1.1
+
+* _version skipped_
+
+## 11.1.0
+
+* _version skipped_
 
 ## 11.0.1
 


### PR DESCRIPTION
In 5f0952a8705f1af4c1ac260b45856c1099abf01e, the version was increased to 11.1.2 (presumably in error) but the `CHANGELOG` entry was made for 11.1.0.

Updating the `CHANGELOG` to reflect the correct version and indicating that the two intermediate releases were skipped.

This repo is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.
